### PR TITLE
Add Progress::add_time(double) accessor

### DIFF
--- a/logging.h
+++ b/logging.h
@@ -17,6 +17,7 @@ public:
     void skip_stage() { _cur_stage++; }
     void update(double progress, int op_count);
     void time_init(double elapsed);
+    void add_time(double seconds) { _time_total += seconds; }
     void set_parent(Progress* parent) { _parent = parent; }
 
     std::vector<double>& costs() { return _costs; }


### PR DESCRIPTION
## Summary

Adds a one-line accessor on `Progress`:

```cpp
void add_time(double seconds) { _time_total += seconds; }
```

This lets callers credit elapsed time directly into `_time_total` without going through `update()`, which has the side effect of overwriting `_cur_progress`.

## Motivation

Needed by a companion fix in `patnashev/prst` for a `time: 0.0 s.` display bug in `MorrisonGeneric` / `PocklingtonGeneric`. Those classes drive their inner tasks through a `SubLogging` whose `progress().set_parent(nullptr)` was set deliberately (to keep the per-task progress fraction from clobbering the outer logical progress), but as a side effect no per-task time ever reached the outer `Progress`. With `add_time()`, the parent-repo fix can push `cur_task->timer()` into the outer progress after each task without touching `_cur_progress`.

Companion PR (should land alongside this one): **patnashev/prst#15** — https://github.com/patnashev/prst/pull/15

## Test plan

- [x] Builds (verified by building the consumer in `patnashev/prst`).
- [x] No call sites in this repo are affected (purely additive).