### PR TITLE
docs: add framework subsystem guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Arithmetic
 C++ framework for working with very large numbers.
+
+Developer documentation (architecture overview and per-subsystem deep-dives) is in [`docs/`](docs/lay-of-the-land.md).

--- a/docs/arithmetic-foundation.md
+++ b/docs/arithmetic-foundation.md
@@ -1,0 +1,235 @@
+# Arithmetic foundation — deep dive
+
+This is the layer everything else rests on. Two data types carry every number in PRST:
+
+- **`Giant`** — an arbitrary-precision integer (the `k`, `b`, `c`, factor lists, residues, RES64s — all the *exact* integers). Backed by a swappable arithmetic strategy: a native giants library, GMP, or a per-GWnum-state allocator.
+- **`GWNum`** — a number in GWnum's FFT/IBDWT representation, the form the *heavy modular multiplication* happens in. Created and operated on by a `GWArithmetic`, configured by a `GWState`.
+
+The bridge between them — and the thing checkpoints persist — is **`SerializedGWNum`** (a `GWNum` flattened to portable words). And the layer that makes long FFT computations trustworthy is **`ReliableGWArithmetic`**, which detects round-off error and escalates. Every other doc in this folder has been quietly leaning on these: `Giant` is the type threaded through `inputnum-parsing.md`, the residues in `run-hierarchy.md` (in the patnashev/prst repo), and the records in `state-serialization.md`; `GWState` is the "math runtime" `main()` hands to every test.
+
+This doc covers this repo's arithmetic source (the `patnashev/arithmetic` library). The actual FFT bignum — **GWnum** (Woltman's `gwnum/`) and **GMP** — are prebuilt third-party libraries: PRST calls their C APIs (`gwsetup`, `gwmul3`, `mpz_*`) but owns no source, so they're understood at the interface here, not dissected. The wire (de)serialization, by contrast — `gwserialize`/`gwdeserialize`/`gwconvert` — is in-tree, defined in `arithmetic/arithmetic.cpp` (§5).
+
+Source files:
+- `arithmetic/giant.{h,cpp}` (`Giant`, `GiantsArithmetic` + the `GW`/`GMP` backends, including the `GMPArithmetic` GMP binding)
+- `arithmetic/arithmetic.{h,cpp}` (`GWState`, `GWArithmetic`, `CarefulGWArithmetic`, `ReliableGWArithmetic`, `GWNum`, `SerializedGWNum`)
+- `arithmetic/integer.{h,cpp}` (small-integer number theory — `gcd`/`inv`/`is_prime`/`phi`/`jacobi`/`kronecker` — and the prime sieve `PrimeList`/`PrimeIterator`)
+
+Prereqs / companions: `inputnum-parsing.md` (`InputNum::value()` returns a `Giant`; `InputNum::setup` drives `GWState::setup` and supplies `known_factors`), `state-serialization.md` (the `Giant` wire encoding and `SerializedGWNum` are what `Writer`/`Reader` move), `task-lifecycle.md` (the `ReliableGWArithmetic` reliable-mode contract it treats as a black box), `run-hierarchy.md` / `proof-system.md` (in the patnashev/prst repo) (every test computes on `GWNum`s).
+
+## 1. Data model
+
+**`Giant` on the heap.** A `Giant` *is* a `giant_struct` (`arithmetic/giant.h:169-176`) wrapped in field-element machinery:
+
+```cpp
+struct giant_struct {
+    int _capacity = 0;        // allocated uint32 words
+    int _size = 0;            // word count; SIGN of _size = sign of the number
+    uint32_t* _data = nullptr; // little-endian base-2^32 limbs; _data[0] is least significant
+};
+class Giant : public FieldElement<GiantsArithmetic, Giant>, protected giant_struct { … };
+```
+
+The field order is not incidental. `arithmetic/giant.cpp:53` defines `#define giant(x) ((::giant)&(x)._capacity)` — it reinterprets the address of `_capacity` as a `::giant` (gwnum's C bignum pointer) and hands it to the native ops (`itog`, `gianttogw`, `mulg`, …), which then read/write the struct in place. For that cast to be valid, `giant_struct`'s layout from `_capacity` onward must match whatever `::giant` points to — so the field order is load-bearing; reordering or inserting a field before them silently corrupts every native call. (The exact C `giant` definition lives in gwnum's `giants.h` — external/prebuilt — so the match is enforced by the cast, not visible here.) (`size()`/`capacity()` translate to 32-bit-word counts; under GMP the stored limbs are `GMP_NUMB_BITS` wide and `size()` converts + trims leading zeros — `arithmetic/giant.cpp:207-228`.)
+
+**The arithmetic strategy.** `Giant` carries no logic; every operation delegates to its `GiantsArithmetic& arithmetic()`. There are four backends (`arithmetic/giant.h`):
+
+| Backend | Role |
+|---|---|
+| `GiantsArithmetic` | the native giants library (default fallback) |
+| `GMPArithmetic` (`arithmetic/giant.{h,cpp}`, `#ifdef GMP`) | GMP-backed (the `mpz_*` binding); **the default when `libgmp` loads** (`arithmetic/giant.cpp:23-37`) |
+| `GWGiantsArithmetic` | native, but allocating out of a `gwhandle`'s memory (capacity sized to the FFT) |
+| `GWGMPArithmetic` | GMP variant of the above |
+
+`GiantsArithmetic::default_arithmetic()` is the process-wide singleton a bare `Giant x;` uses; `alloc_gwgiants(gwdata, capacity)` makes the per-`GWState` allocator (`arithmetic/giant.cpp:44-51`). So "which arithmetic" is chosen at construction and threaded through every op — a `Giant` and its arithmetic are inseparable.
+
+**`GWNum` and friends.** A `GWNum` (`arithmetic/arithmetic.h:225`) wraps a single `gwnum _gwnum` (an FFT-domain buffer, `gwalloc`/`gwfree`). It's operated on by a `GWArithmetic` (the math) over a `GWState` (the config + handle). `SerializedGWNum` (`arithmetic/arithmetic.h:207`) is a `std::vector<uint32_t>` holding the `gwserialize` output of a `GWNum` — the only `GWNum` form that survives to disk. `GWNumWrapper` (`arithmetic/arithmetic.h:345`) is a non-owning view (doesn't free on destruct).
+
+## 2. `GWState::setup` — the central method
+
+`GWState` is the math runtime: it owns the `gwhandle handle`, the modulus `N`, the per-state `giants` allocator, the `fingerprint`, and the FFT description. The most illuminating method is the `k·b^n+c` setup (`arithmetic/arithmetic.cpp:58-84`), verbatim:
+
+```cpp
+void GWState::setup(uint64_t k, uint64_t b, uint64_t n, int64_t c)
+{
+    if (k >= (1ULL << 51) || b >= (1ULL << 32) || n >= (1ULL << 32) || std::abs(c) >= (1ULL << 30))
+        throw ArithmeticException();                       // the fast-form domain limits
+    Giant tmp;
+    tmp.arithmetic().init((uint32_t*)&k, 2, tmp);
+    tmp = tmp*power((Giant() = (uint32_t)b), (uint32_t)n) + c;   // N = k*b^n + c, as a Giant
+    init();
+    if (gwsetup(gwdata(), (double)k, (uint32_t)b, (uint32_t)n, (int32_t)c))   // configure the IBDWT FFT
+        throw ArithmeticException();
+    bit_length = (int)gwdata()->bit_length;
+    if (gwdata()->GENERAL_MOD)
+        bit_length /= 2;
+    giants.reset(GiantsArithmetic::alloc_gwgiants(gwdata(), (bit_length >> 5) + 10));  // FFT-sized Giant allocator
+    N.reset(new Giant(std::move(tmp)));
+    if (gwdata()->GENERAL_MOD)
+        bit_length = N->bitlen();
+    fingerprint = *N%3417905339UL;                         // SAME modulus as InputNum::fingerprint
+    if (!known_factors.empty() && known_factors > 1 && *N%known_factors != 0)
+        throw ArithmeticException();
+    if (!known_factors.empty() && known_factors > 1)
+        *N /= known_factors;                               // divide out the known algebraic cofactor
+    char buf[200];
+    gwfft_description(gwdata(), buf);
+    fft_description = buf;                                  // e.g. "FMA3 FFT length 512K"
+    fft_length = (int)gwfftlen(gwdata());
+}
+```
+
+Three things to read out of this:
+1. **The fast-form domain is bounded** — `k < 2^51`, `b`/`n < 2^32`, `|c| < 2^30`. Outside it, callers use `setup(const Giant&)` (`gwsetup_general_mod`, a slower generic modulus) or `setup(int bitlen)` (`gwsetup_without_mod`, no modulus at all). `InputNum::setup` chooses among these (`inputnum-parsing.md` §4).
+2. **`fingerprint = *N % 3417905339`** is computed here from the *actual* modulus GWnum built — and it's the **same constant** `InputNum::fingerprint()` uses. That's the cross-check: if the FFT was configured for the wrong number, the fingerprints disagree and the test aborts (the `ArithmeticException` you saw at the tail of `InputNum::setup`).
+3. **`known_factors` is the algebraic-cofactor trick made concrete** — when `InputNum` recognized a `Phi`/`Quad`/`Hex` form, it set up GWnum modulo the *larger* fast-form multiple and passed the cofactor as `known_factors`; here it's divided out (`*N /= known_factors`), leaving the candidate as the working modulus while keeping the fast FFT (`inputnum-parsing.md` §6).
+
+## 3. Field & method reference
+
+**`Giant`** (`arithmetic/giant.h:176-550`):
+
+| Member | Note |
+|---|---|
+| `data()` / `size()` / `capacity()` | raw limbs; word count (sign-stripped, GMP-translated); allocated words. |
+| `empty()` | `_data == nullptr` (uninitialized — distinct from value 0). |
+| `bitlen()` / `bit(i)` | bit length / bit test. |
+| `to_string()` / `to_res64()` / `digits()` | decimal; low-64-bits hex (`"%08X%08X"`, `arithmetic/giant.cpp:185`); digit count. |
+| operators `+ - * / % << >> == < …` | each constructs a result and delegates to `arithmetic()`. Mixed-type overloads for `uint32_t`/`int64_t`/`uint64_t` via the `GIANT_INIT_ADD_SUB` macro. |
+| `power` / `gcd` / `inv` / `powermod` / `kronecker` / `rnd` / `substr` | number-theory ops, all on the backend. |
+| `= GWNum` / `to_GWNum` | convert to/from the FFT form (`gianttogw`; negatives get `N` added first — mod-`N` representation, `arithmetic/giant.cpp:195-205`). |
+
+**`GWState`** (`arithmetic/arithmetic.h:13-80`) — config knobs (set before `setup`) and live state (set by `setup`):
+
+| Field | Kind | Meaning |
+|---|---|---|
+| `thread_count`, `spin_threads`, `instructions`, `next_fft_count`, `safety_margin`, `force_mod_type`, `large_pages` | config | FFT engine selection / sizing / threading. |
+| `maxmulbyconst` | config | upper bound for `setmulbyconst` (the Fermat base `a`); set by `Run::create`. |
+| `known_factors` | config | algebraic cofactor to divide out (§2). |
+| `information_only` | config | report the FFT and abort (the `-fft info` path). |
+| `handle` (`gwhandle`) | live | the GWnum library state. |
+| `N` | live | the modulus `Giant` (null after `setup(bitlen)`). |
+| `giants` | live | the FFT-sized `Giant` allocator. |
+| `fingerprint`, `fft_description`, `fft_length`, `bit_length` | live | identity + FFT facts. |
+| `mod_gwstate` | live | the secondary `GWState` that backs `mod()` (the known-factor reduction). Lazily created on the first `mod()` call (`force_mod_type=2`; set up over `*N`, or `square(*N)` under `GENERAL_MOD`) and used on *every* `mod()` call; the internal `known_factors > *N` test only adds one extra nested `mod_gwstate->mod()` reduction pass (`arithmetic/arithmetic.cpp:153-176`). `mod()` runs when `need_mod()` is true, i.e. `known_factors > 1`. |
+
+Methods: `setup(k,b,n,c)` / `setup(Giant)` / `setup(bitlen)` (the three FFT configs), `copy(state)` (config only — **not** the live handle/N; you must `setup` after — this is what `-batch` uses per candidate), `clone(state)` (the deeper path that `gwclone`s the live handle, reached via the `GWState(GWState&)` copy-constructor; PRST's own code has no direct caller today), `done()` (`gwdone`+`gwinit`, the teardown), `need_mod()`/`mod()` (known-factor reduction), `ops()` (FFT-count → normalized op count).
+
+**`GWArithmetic`** (`arithmetic/arithmetic.h:87-152`) — the FFT math over a `GWState`: `add`/`sub`/`mul`/`square`/`div`/`inv` plus fused `addmul`/`muladd`/`mulsub`/`mulmuladd`/… each taking GWnum `options` (`GWMUL_*` flags: which operands to preserve, whether to normalize). `setmulbyconst`/`setaddin`/`setpostaddin` tune the next multiply (asserting `|a| ≤ maxmulbyconst`). `popg()` mints a `Giant` from the state's allocator; `N()` is the modulus; `carefully()` returns the careful variant. Subclasses:
+- **`CarefulGWArithmetic`** — `gwmul3_carefully` etc.: exact, slower, round-off-free. The `CarefulExp` tasks use it for short/exact legs.
+- **`ReliableGWArithmetic`** — round-off-checked with escalation (§5).
+
+**`GWNum`** (`arithmetic/arithmetic.h:225-343`) — `= Giant` (`gianttogw`), `= SerializedGWNum` (`gwdeserialize`), `to_string`. Division is `a * b.inv()` (GWnum has no native divide). `*num` yields the raw `gwnum`.
+
+## 4. Lifecycle: how a test uses the layer
+
+A test's path through this layer (drives the cadence in `task-lifecycle.md`):
+
+1. **Configure.** `main()` fills a `GWState`'s config fields from the CLI; `InputNum::setup(gwstate)` picks `setup(k,b,n,c)` / `setup(Giant)` / `setup(bitlen)` and verifies the fingerprint. Now `gwstate.N`, `giants`, `fft_description` are live.
+2. **Allocate.** The test makes a `GWArithmetic gw(gwstate)` and `GWNum`s from it (`gwalloc`).
+3. **Compute.** The exponentiation/Lucas loop calls `gw.mul(...)` (or the reliable/careful variant) millions of times — this is the wall-clock. `setmulbyconst(a)` folds the Fermat base into the squaring.
+4. **Checkpoint.** On the `DISK_WRITE_TIME` cadence, the current `GWNum` is captured into a `SerializedGWNum` (and exact values into `Giant`s) inside a `TaskState`, written by `File::write` (`state-serialization.md`). On resume, `= SerializedGWNum` deserializes it back.
+5. **Finish + reduce.** The result `GWNum` is converted to a `Giant` (`= GWNum`), reduced mod `N` if `need_mod()`, and compared / `to_res64`'d for the result line.
+6. **Teardown.** `gwstate.done()`; for `-batch`, a fresh `clone`/`copy`+`setup` per candidate.
+
+`copy()` vs `clone()` is a real distinction: `copy()` brings only the config fields (not the live handle/N), so batch (`prst/src/batch.cpp:310`) does `gwstate_cur.copy(gwstate)` then `input.setup(gwstate_cur)` to build a fresh FFT per candidate (BOINC's resume likewise relies on `setup` recomputing everything). `clone()` is the deeper `gwclone`-the-handle path, reached only via the `GWState` copy-constructor — not called directly in PRST's own code today.
+
+## 5. SerializedGWNum and ReliableGWArithmetic
+
+**`SerializedGWNum`** (`arithmetic/arithmetic.cpp:878-895`) is the checkpoint bridge. Assigning from a `GWNum` calls `gwserialize` twice — once with a null buffer to learn the length (it returns `GWERROR_MALLOC` with `-len`), then again to fill a resized `vector<uint32_t>`:
+
+```cpp
+SerializedGWNum& SerializedGWNum::operator = (const GWNum& a)
+{
+    int len;
+    if (gwserialize(a.arithmetic().gwdata(), *a, NULL, 0, &len) != GWERROR_MALLOC) throw ArithmeticException();
+    _data.resize(-len);
+    if (gwserialize(a.arithmetic().gwdata(), *a, _data.data(), (int)_data.size(), &len) != 0 || _data.size() != len) throw ArithmeticException();
+    return *this;
+}
+```
+
+`to_GWNum` is `gwdeserialize` (or `0` if empty). Both calls take the `gwhandle`, so a value is serialized/deserialized *through* a configured FFT. Unlike `gwsetup`/`gwmul3`, the serializer is **in-tree**: `gwserialize`/`gwdeserialize`/`gwconvert` are all defined right here in `arithmetic/arithmetic.cpp` (the ~470-line block at `arithmetic/arithmetic.cpp:898-1405`). The wire format is a 6-word header (`GWSERIALIZE_HEADER_SIZE`, `arithmetic/arithmetic.cpp:1033`) carrying flags (`GWSERIALIZE_FLAG_IRRATIONAL`/`GENERALMOD`/`MMGW_MOD`, `:1034-1036`) plus the stored `b`/`FFTLEN`/`k` and `NUM_B_PER_SMALL_WORD` (written at `arithmetic/arithmetic.cpp:1128-1132`), followed by the FFT words. Because the format records the source FFT's length and base, `gwdeserialize` handles the cross-FFT-length question itself — see §8.
+
+**`ReliableGWArithmetic`** (`arithmetic/arithmetic.cpp:528-592`) is the answer to "FFT multiplication is approximate — how do we trust a billion-squaring result?" Its `mul` escalates in three tiers, tracking an op counter:
+
+```cpp
+void ReliableGWArithmetic::mul(GWNum& a, GWNum& b, GWNum& res, int options)
+{
+    bool suspect = _suspect_ops.count(_op) != 0;
+    if (!suspect) {
+        gwerror_checking(gwdata(), true);
+        gwmul3(gwdata(), *a, *b, *res, options);             // 1. normal, error-checked
+        gwerror_checking(gwdata(), false);
+        if (gw_get_maxerr(gwdata()) > _max_roundoff) {        // round-off too high (> 0.4)
+            gw_clear_maxerr(gwdata());
+            _suspect_ops.insert(_op);
+            if (*res == *a || *res == *b) _restart_flag = true;  // in-place → can't redo here
+            else suspect = true;
+        }
+    }
+    if (suspect) {
+        GWNum s1 = a; GWNum s2 = b;
+        gwmul3(gwdata(), *a, *b, *res, options);              // 2. retry (maybe a HW glitch)
+        if (gw_get_maxerr(gwdata()) > _max_roundoff) {
+            gwmul3_carefully(gwdata(), *s1, …, *res, …);       // 3. careful (exact) retry
+            if (gw_get_maxerr(gwdata()) > _max_roundoff) _failure_flag = true;  // FFT too small
+        }
+        else _suspect_ops.erase(_op);                         // it was a HW glitch, not a real suspect
+    }
+    _op++;
+}
+```
+
+The contract (the surface `task-lifecycle.md` §8 treats as a black box):
+- **`_op`** — monotonic operation index; the position in the computation.
+- **`_suspect_ops`** — op-indices that once exceeded round-off; on a re-run they're done carefully from the start.
+- **`restart_flag()`** — an in-place op overflowed and can't be redone in place ⇒ the caller **must** restart from the last checkpoint (this time the suspect op is in the set). Ignoring it silently keeps a bad result.
+- **`failure_flag()`** — even careful arithmetic overflowed ⇒ the FFT is too small; bump `next_fft_count` and re-setup.
+- **`reset()`** clears everything; **`restart(op)`** rewinds `_op` to a checkpoint position but keeps `_suspect_ops`. `_max_roundoff = 0.4`.
+
+## 6. Pitfalls
+
+- **`Giant`'s field order is an ABI contract with gwnum's C `giant`.** The `giant(x)` cast (`arithmetic/giant.cpp:53`) reinterprets `&_capacity` as a `::giant*`. Reordering `_capacity`/`_size`/`_data`, or adding a field before them, silently corrupts every native giants call. They live where they do *because* the C struct does.
+- **`_size` is signed; `size()` is not.** The sign of `_size` is the number's sign; `size()` returns the magnitude word count. Reading `data()` without consulting the sign mishandles negatives — and `to_GWNum` adds `N` to a negative `Giant` first (mod-`N` form). The on-disk encoding (`state-serialization.md`) carries the sign in the length field for the same reason.
+- **`SerializedGWNum` is tied to its modulus, but cross-FFT-length loading is defined in-tree.** It's the `gwserialize`/`gwdeserialize` wire form (both in `arithmetic/arithmetic.cpp`), always handled through a `gwhandle`, and meaningful only for the *number* it was serialized for. Loading into a *different-length* FFT is handled explicitly by `gwdeserialize` (§8): same length is the fast path, a **smaller** target transform throws (`"Can't deserialize to smaller transform."`), and a **larger** one re-radix-converts. So a checkpoint survives a reliable-mode FFT *bump* (larger), which is exactly the direction the bump goes.
+- **`restart_flag` / `failure_flag` are not optional.** They're the only signal that an FFT result is untrustworthy; the `Task` loop polls them and restarts / enlarges the FFT. New code driving `ReliableGWArithmetic` directly that forgets to check them will commit corrupt residues.
+- **`GWState::copy` is config-only.** It copies thread count, FFT hints, `known_factors`, etc., but **not** `handle`/`N`/`giants`. A copied state is unusable until `setup()`. (`clone()` is the one that brings the live FFT across, via `gwclone`.)
+- **GMP vs native changes `size()`/`capacity()` semantics.** Under GMP the stored limbs are `GMP_NUMB_BITS` wide; `size()`/`capacity()` translate to 32-bit words on the fly (`arithmetic/giant.cpp:207-228`). Code poking `data()` must know which backend is active — the default is GMP when `libgmp` loads.
+- **`maxmulbyconst` gates `setmulbyconst`.** `setmulbyconst(a)` asserts `|a| ≤ state.maxmulbyconst` (`arithmetic/arithmetic.h:136`). `Run::create` sets `options.maxmulbyconst` to the base; setting a base above it trips a `GWASSERT`.
+
+## 7. Quick reference
+
+| You want to… | Call |
+|---|---|
+| A scratch big integer | `Giant g;` (uses `default_arithmetic`, GMP if present) |
+| Configure the FFT for `k·b^n+c` | `gwstate.setup(k, b, n, c)` (bounds: k<2⁵¹, b,n<2³², \|c\|<2³⁰) |
+| …for an arbitrary modulus | `gwstate.setup(someGiant)` (general mod, slower) |
+| …with no modulus | `gwstate.setup(bitlen)` |
+| Per-candidate FFT in a batch | `dst.copy(src)` then `input.setup(dst)` |
+| Multiply in the FFT domain | `gw.mul(a, b, res, options)` (or `gw.square`) |
+| Exact / round-off-free op | `gw.carefully().mul(...)` |
+| Round-off-checked op + retry | `ReliableGWArithmetic`; **check `restart_flag()`/`failure_flag()`** |
+| `GWNum` → exact integer | `Giant g = gwnum;` (adds `N` if negative) |
+| Persist a `GWNum` | assign to a `SerializedGWNum` (loadable into a same-or-larger FFT; §8) |
+| Low 64 bits as hex (RES64) | `g.to_res64()` |
+| Identity / FFT facts | `gwstate.fingerprint`, `.fft_description`, `.fft_length` |
+
+## 8. Open questions / non-coverage
+
+- **GWnum itself.** `gwsetup`/`gwmul3`/`gwmul3_carefully`/`gwfft_description` and the FFT-size/instruction-set selection are Woltman's prebuilt library (`gwnum/`); PRST uses the API and the `gwhandle` fields (`GENERAL_MOD`, `bit_length`, `mulbyconst`) but doesn't own the source. Treated as the interface contract, not dissected. Likewise GMP via `arithmetic/giant.cpp`'s `GMPArithmetic` — the *binding* is in scope (and partly shown), the GMP internals aren't. (Note: the (de)serialization path — `gwserialize`/`gwdeserialize`/`gwconvert` — is *not* external; it's defined in this repo's `arithmetic/arithmetic.cpp`, see §5/§8.)
+- **The `arithmetic/giant.cpp` GMP binding in full.** This doc covers `GMPArithmetic`'s *role* (default backend) and the `size()`/`capacity()` translation; the per-op GMP glue (`mpz_*` calls for `mul`/`gcd`/`powermod`/`kronecker`/…) is the bulk of `arithmetic/giant.cpp`'s mechanical binding, summarized not enumerated.
+- **The wider arithmetic library.** Elliptic-curve (`edwards`/`montgomery`/`group`), polynomial (`poly`), and Lucas-sequence (`lucas`) arithmetic build *on* `Giant`/`GWNum` but are their own subsystem → `curves-and-polynomials.md`.
+- **`SerializedGWNum` cross-FFT portability — resolved.** Can a value serialized under FFT length L be `gwdeserialize`d into a length-L′ FFT for the same modulus? `gwdeserialize` (`arithmetic/arithmetic.cpp:1141-1405`) answers it in-tree by comparing the header's stored `FFTLEN`/`b`/flags against the live `gwdata`: an **identical**-length match is the fast path that copies the FFT words directly (`arithmetic/arithmetic.cpp:1156-1181`); deserializing into a **smaller** transform throws `"Can't deserialize to smaller transform."` (`arithmetic/arithmetic.cpp:1183-1186`); a **larger** transform re-radix-converts word-by-word into the wider layout (`arithmetic/arithmetic.cpp:1188-1395`), with extra carefully-multiplied correction factors for the `GENERAL_MOD`/`MMGW_MOD` mode changes. So a checkpoint resumes cleanly across a reliable-mode FFT *bump* (which only grows the transform); the `task.cpp:140-146` continue-from-`_state` path relies on exactly the larger-transform branch.
+- **Why the round-off threshold is 0.4, and the IBDWT error theory.** `_max_roundoff = 0.4` is a tuning constant; the numerical-analysis justification (why that bounds a correct convolution) is GWnum/multiplication-theory territory → `math-and-theorems.md` (in the patnashev/prst repo) and the `mult_*.pdf`s.
+- **`ThreadSafeGWArithmetic` / `PolyMult`.** Friend classes named in `arithmetic/arithmetic.h` (`GWNum`'s friends) but not part of the single-`Task` main path; relevant only if multi-`Task` parallelism is added (cross-ref the parked thread-safety question in lay-of-the-land (in the patnashev/prst repo)).
+
+## 9. `arithmetic/integer.cpp` — number theory & the prime sieve
+
+`arithmetic/integer.{h,cpp}` is the small-integer companion to the big-`Giant` layer: 32/64-bit number theory plus a process-wide prime generator. Nothing here is GMP glue (that lives in `arithmetic/giant.cpp`, §1) — it's plain `uint32_t`/`uint64_t` math that the candidate-parsing and factor-walk code leans on.
+
+**Free functions** (`arithmetic/integer.h:9-25`, `arithmetic/integer.cpp:8-162`). Header-declared `uint32_t` helpers with `int` overloads: `gcd`/`inv` (Euclid and modular inverse), `is_prime` and `phi` (both trial-divide via the iterator below — `is_prime` up to `√a`, `phi` factoring `N` as it goes), and the Legendre/Jacobi/Kronecker symbols `jacobi`/`kronecker` (`arithmetic/integer.cpp:66-162`, the classic bit-twiddling implementations that fall back to returning a `gcd` when the arguments aren't coprime). These are interface-level utilities — small, exact, and stateless.
+
+**`PrimeList`** (`arithmetic/integer.h:29-49`) is a sieved table of primes below a bound. The one that matters is the process-wide 16-bit cache: `PrimeList::primes_16bit()` (`arithmetic/integer.h:43`) lazily builds and returns a singleton `PrimeList(65536)` — every prime below 2¹⁶ (6542 of them, the same constant that opens the `_31bit_prime_count` table). The constructor (`arithmetic/integer.cpp:166-186`) is an odds-only bit-sieve; `sieve_range(start, end, list)` (`arithmetic/integer.cpp:226-230`) sieves an arbitrary `int` window on top of it.
+
+**`PrimeIterator`** (`arithmetic/integer.h:51-99`) is the forward primes-as-a-stream view. `PrimeIterator::get()` (`arithmetic/integer.h:69`) starts at 2 over the 16-bit cache; `+= offset`, `++`, `find(prime)`, and `max()` walk it. Past the cached 16-bit range it transparently extends to 31-bit primes by sieving 64K-wide segments on demand (`init_range` → `PrimeList::sieve_range`, `arithmetic/integer.cpp:240-251`), and `sieve_range(start, end, list)` (`arithmetic/integer.cpp:314-316`) exposes a segmented 64-bit sieve over the shared `sieve_range_t` template (`arithmetic/integer.cpp:188-224`). To make seeking cheap, segment boundaries are precomputed from a large static delta-table: `_31bit_prime_count[]` (`arithmetic/integer.cpp:319-1343`) is folded by `init_31bit_prime_pos()` (`arithmetic/integer.cpp:1345-1357`) into a cumulative prime-position index `_31bit_prime_pos`. That static table is the bulk of the file — it is why `arithmetic/integer.cpp` is ~124 KB (1358 lines) despite the actual logic being a few hundred lines; treat the table itself as opaque generated data.
+
+**Who consumes them.** `InputNum` parsing/factoring uses `PrimeIterator` and `kronecker` (`inputnum.cpp:311`, `:488`, `:1572`, `:1589`, `:1691`, `:1941`). The Pocklington and Morrison certificate walks pick witness primes / Lucas parameters through `PrimeIterator::get()` and `kronecker` (`prst/src/pocklington.cpp:148`, `:579-582`; `prst/src/morrison.cpp:167`, `:190`, `:393`, `:466`, `:830`). Others (`prst/src/order.cpp`, `prst/src/fermat.cpp`, `prst/src/abc_parser.cpp`, the EC `arithmetic/group.cpp`) draw on the same free functions and iterator. So although it sits below the FFT machinery, this module is a real dependency of the test setup — not optional plumbing.

--- a/docs/config-dsl.md
+++ b/docs/config-dsl.md
@@ -1,0 +1,170 @@
+# Config DSL — deep dive
+
+Every PRST front-end — `main`, `batch_main`, `boinc_main`, `net_main` — declares its command line the same way: a fluent `Config` chain that *builds a tree*, then `parse_args(argc, argv)` walks `argv` against that tree, writing straight into `Options` / `GWState` / local variables. So to understand any entry point's flags you have to understand this one DSL. It also reads `.ini` files through the same tree.
+
+There are **two parallel hierarchies** and the trick is keeping them apart:
+
+1. **The runtime tree** — `ConfigObject` and its subclasses (`ConfigKey`, `ConfigKeyValue`, `ConfigGroup`, `ConfigExclusive`, `ConfigKeyList`). This is what actually exists at parse time and consumes `argv`.
+2. **The builder layer** — the `*Setup` class templates (`ConfigGroupSetup`, `ConfigExclusiveSetup`, …), a CRTP fluent API whose only job is to *construct* the runtime tree as you chain calls. Once `parse_args` runs, the builder is gone; only the tree matters.
+
+A reader who conflates the two gets lost: the verbs you type (`value_number`, `group`, `exclusive`, `end`) are builder methods; the objects they leave behind (`ConfigKeyValueNumber`, `ConfigGroup`, …) are what parse.
+
+Source files:
+- `config.h` (both hierarchies — the runtime `ConfigObject`s and the `*Setup` builders)
+- `config.cpp` (`parse_args`/`parse_ini` per object type, `parse_number`)
+
+Prereqs / companions: the entry-point docs that show real chains — `abc-batch.md` (in the patnashev/prst repo) §3 (`batch_main`), `boinc-and-net.md` (in the patnashev/prst repo) §2 (`boinc_main`), and `prst/src/prst.cpp:82+` (`main`); `arithmetic-foundation.md` (`GWState`, a common parse target); `state-serialization.md` (`File`/`TextReader`, which `parse_ini` reads through).
+
+## 1. The two hierarchies
+
+**Runtime tree** (`config.h`), each node a `ConfigObject` with `parse_args(argc, argv, cur)` / `parse_ini(...)`:
+
+| Node | Matches | Effect |
+|---|---|---|
+| `ConfigKey` (plain) | a bare flag token (`-batch`) | nothing — `ignore`. |
+| `ConfigKeyCheck<T,V>` | a flag | `dst = value` (e.g. `-d` → `log_level = LEVEL_INFO`). |
+| `ConfigKeyCode` | a flag | runs a `std::function<void()>`. |
+| `ConfigKeyValue*` | `key`+`delim`+`value` | sets a target via `set_value`. Subtypes: `…Number<T,V>` (range-checked), `…String`, `…Enum<T,V>` (string→enum via `Enum`), `…Code` (`std::function<bool(const char*)>`). |
+| `ConfigKeyList` | `key` then N values | fills N targets (one per registered value); `_list_delim` separates them (a char, or `' '` = successive `argv` tokens). |
+| `ConfigGroup` | a name token, then greedily its sub-keys | a prefix namespace (`-fft`, `-check`, `-time`). |
+| `ConfigExclusive` | the first of its `ConfigCase`s that matches | mutually-exclusive options; once one matches, only its `optional()` sub-keys are accepted. |
+| `Config` | — | the root `ConfigGroup` + a `_default_code` for unmatched tokens. |
+
+Every `ConfigObject` also carries an optional **`_parsed`** hook (a `ConfigKey`), run by `on_parsed()` *after* the object successfully parses — this is how `on_check`/`on_code` attach a side effect ("if `-fermat` appeared at all, set `ForceFermat = true`").
+
+**Builder layer** (the `*Setup` CRTP templates). `ConfigGroupSetup<P, R>` carries the verbs (`value_number`, `check`, `group`, …); `P` is the concrete setup type each verb returns (so chaining stays typed), `R` is the parent returned by `end()`. `group()`/`list()`/`exclusive()` descend into child setups; `end()` climbs back. `Config` is *both* a `ConfigGroup` and a `ConfigGroupSetup<Config, nullptr_t>`, so the root is its own builder — that's why `Config cnfg; cnfg.value_number(...).group(...)…` works.
+
+## 2. `parse_args` — the central methods
+
+Two methods carry the dispatch. The **top loop** (`config.cpp:16-30`):
+
+```cpp
+void Config::parse_args(int argc, char *argv[])
+{
+    int cur = 1;
+    while (cur < argc)
+    {
+        int last = cur;
+        for (auto it = _objects.begin(); it != _objects.end(); it++)
+            (*it)->parse_args(argc, argv, cur);     // each object advances cur iff it matches
+        if (cur == last)                            // nothing matched argv[cur]
+        {
+            _default_code(argv[cur]);               // → the input number / batch file
+            cur++;
+        }
+    }
+}
+```
+
+Objects are tried **in registration order**; a match advances `cur`, an unmatched token falls to `_default_code`. The **matcher** that most flags use, `ConfigKeyValue::parse_args` (`config.cpp:224-256`), is where the `delim` convention lives:
+
+```cpp
+void ConfigKeyValue::parse_args(int argc, char *argv[], int& cur)
+{
+    if (cur >= argc) return;
+    if (strncmp(argv[cur], _name.data(), _name.size()) != 0) return;  // argv must START WITH the key
+    char* val_s = argv[cur] + _name.size();         // …the rest is the candidate value
+    int inc = 1;
+    if (_delim == ' ') {                             // value is the NEXT token:  "-t 4"
+        if (*val_s != 0) return;                     //   key must be a whole token
+        if (cur + 1 >= argc) return;
+        val_s = argv[cur + 1]; inc = 2;
+    }
+    else if (_delim != 0) {                          // value follows a literal delim: "-fft+1"
+        if (*val_s != _delim) return;
+        val_s++;
+    }
+    else {                                           // glued:  "-t4"
+        if (*val_s == 0) return;
+    }
+    if (!set_value(val_s)) return;                   // range/format check; failure = no match
+    cur += inc;
+    on_parsed();                                     // fire the on_check/on_code hook
+}
+```
+
+Three `delim` modes, all in use:
+- **`' '`** — value is the following `argv` token (`-t 4`, `-fermat a 3`).
+- **`0`** — value is glued to the key in the same token (`-t4`).
+- **any other char** — value follows that literal in the token (`-fft+1`, delim `'+'`).
+
+`main`/`batch_main` register `-t` *both* ways (`value_number("-t", 0, …)` and `value_number("-t", ' ', …)`) so `-t4` and `-t 4` both work. A failed `set_value` (out of range, non-numeric, unknown enum) is treated as **no match**, so the token can fall through to another object — this is the main guard against prefix collisions (a `-t` value-key declines `-time`, because `set_value("ime")` fails the number parse). It's not foolproof: a longer key whose tail *is* a valid value could still be mis-claimed, so it works because the actual keys are chosen not to collide that way (see §6).
+
+`ConfigKey::parse_args` (flags) is stricter: the rest after the name must be **empty** (`-d`, not `-debug`), then it runs `on_key()` (the side effect) and `on_parsed()`.
+
+## 3. Builder-verb reference
+
+All on `ConfigGroupSetup` (so available at the root and inside any `group`/`exclusive` case):
+
+| Verb | Builds | Meaning |
+|---|---|---|
+| `ignore(key)` | `ConfigKey` | match a flag and do nothing (`-batch`/`-boinc` ignored by the sub-`main` that already dispatched on it). |
+| `check(key, dst, value)` | `ConfigKeyCheck` | flag → `dst = value`. |
+| `check_code(key, fn)` | `ConfigKeyCode` | flag → run `fn()`. |
+| `value_number(key, delim, dst, min, max)` | `ConfigKeyValueNumber` | parse a number into `dst`, range-checked. `dst` may be `std::optional<T>`. |
+| `value_string(key, delim, dst)` | `ConfigKeyValueString` | copy the raw string. |
+| `value_enum(key, delim, dst, Enum)` | `ConfigKeyValueEnum` | map a string to an enum value via an `Enum<V>` (`.add("AVX","AVX")…`). |
+| `value_code(key, delim, fn)` | `ConfigKeyValueCode` | hand the value to `fn(const char*) → bool` (e.g. `-order`, `-ini`). |
+| `group(key)` | `ConfigGroup` → child setup | a prefix namespace; chain its sub-keys, then `end()`. |
+| `list(key, delim, list_delim, fixed?)` | `ConfigKeyList` → child setup | a key followed by several values (e.g. `-proof name <pt> <prod>`); chain `value_*`, then `end()`. |
+| `exclusive()` | `ConfigExclusive` → child setup | open a set of mutually-exclusive `ex_case()`s. |
+| `ex_case()` / `optional()` | `ConfigCase` / its optional group | one alternative; `optional()` holds keys allowed only once the case matched. |
+| `on_check(dst, value)` / `on_code(fn)` | sets `_parsed` on the **last-added object** | a side effect that fires when that object (often a whole `group`) parses. |
+| `end()` | — | climb back to the parent setup. |
+| `default_code(fn)` (root only) | sets `Config::_default_code` | the catch-all for unmatched tokens — the candidate expression or batch filename. |
+
+`parse_number` (`config.cpp:190-208`) accepts an order suffix: `k`/`K`=10³, `M`=10⁶, `G`=10⁹, `T`=10¹², `P`=10¹⁵ — applied *before* the range check (so `-t 1k` parses 1000, then fails `max 256`).
+
+## 4. How a chain parses
+
+1. **Build.** The fluent chain runs at construction, leaving a `ConfigObject` tree under the root `Config`. Nothing parses yet.
+2. **Walk.** `parse_args` loops `argv`; each pass tries every root object in order. A named **`ConfigGroup`** that matches its name token then runs its own fixpoint loop (`config.cpp:311-318`): re-scan its sub-objects until a full pass consumes nothing. So after `-fft`, the tokens `+1 safety 0.5 generic` can appear in any order and each is consumed by a sub-key; the first token that *no* sub-key matches ends the group.
+3. **Exclusive.** A `ConfigExclusive` tries each `ConfigCase` until one matches; a case matches only if it consumes **all** its required objects (`ConfigCase::parse_args`, `config.cpp:471-499`). The winning case is latched in `_case`, and from then on only its `optional()` keys are accepted.
+4. **Fall through.** Any token no object consumed in a full root pass goes to `_default_code`.
+5. **Side effects.** Each successful parse calls `on_parsed()`, firing any `on_check`/`on_code` hook attached to that object.
+
+**`.ini` files** (`parse_ini`, `config.cpp:32-87`) go through the same tree: `[section]` → group `-section`, `key=value` → a key under that group, bare `key` → a valueless flag, `;`/`#` → comment. Nested groups use `\` in section names. One normalization to know when writing an `.ini` (`config.cpp:57-59`): **top-level** keys are stored with a leading `-` prepended (so an `.ini` line `t=4` matches the `-t` flag), but keys **inside a `[section]`** are kept bare (matching the group's sub-key names like `safety`, `generic`). The tree is matched against the parsed `values` map; leftover entries print `Unknown option …`. (`-ini <file>` itself is a `value_code` that reads the file via `File`/`TextReader` and calls `parse_ini`.)
+
+## 5. Common patterns
+
+- **Dual `-t4` / `-t 4`.** Register the same key with `delim 0` and `delim ' '`. Order them glued-first; the glued one fails `set_value` on an empty value and falls through to the spaced one for `-t 4`.
+- **Prefix group.** `group("-fft").value_number("+", 0, …).value_number("safety", ' ', …).check("generic", …).end()` — `-fft +1 safety 0.5 generic`. Note `"+"` with `delim 0` inside the group makes `+1` parse as the `+` key glued to `1`.
+- **Group-level flag via `on_check`.** `group("-fermat").value_number("a", ' ', …).end().on_check(options.ForceFermat, true)` — `a` is optional, but the mere presence of `-fermat` sets `ForceFermat` (the hook fires on the group's own parse).
+- **Exclusive switches.** `group("-check").exclusive().ex_case().check_code("near", […]).end().ex_case().check_code("always", […]).end()…end()` — `-check near|always|never`, first match wins.
+- **Positional list.** `group("-proof").exclusive().ex_case().value_number("save", ' ', count, …).optional().list("name", ' ', ' ').value_string(pt).value_string(prod).end()…` — `-proof save N name <pt> <prod>`.
+- **Catch-all.** `default_code([&](const char* p){ if (!input.parse(p)) printf("Unknown option %s.\n", p); })` — the candidate number; in `batch_main` it's the batch filename.
+
+## 6. Pitfalls
+
+- **Registration order is matching priority.** Objects are tried in the order added (`config.cpp:22`, `:315`); the first to consume a token wins that pass. Reordering a chain can change which key claims an ambiguous token. Value-keys are partly self-protecting (a failed `set_value` declines the token), but flags (`ConfigKey`, exact-match) and groups (exact name) are not order-sensitive only because they require the rest of the token to be empty.
+- **`delim` is the most error-prone knob.** `0` = glued, `' '` = next token, anything else = literal separator. Picking `' '` when you meant `0` (or vice-versa) silently makes a flag never match (it waits for a separate token that never comes, or expects a glued value that isn't there).
+- **`on_check`/`on_code` bind to the *last-added* object.** They must be placed immediately after the object (often a `group(...).end()`) they annotate; put elsewhere they attach to the wrong node. The hook fires on that object's *successful parse*, not unconditionally.
+- **A partially-matched exclusive case still ran its side effects.** `ConfigCase::parse_args` commits `cur` only if it consumes *all* its objects, but the `set_value`/`on_key` calls of the ones it *did* match already mutated their targets — and (unlike `parse_ini`, which saves/restores copies, `config.cpp:533-538`) `parse_args` does **not** roll them back. Harmless for the usual single-key cases, latent for multi-key ones.
+- **Order suffixes apply before range-checking.** `parse_number` multiplies by `k`/`M`/`G`/… first, so a suffixed value can overflow or exceed `max` and be *rejected* (declining the token) rather than clamped.
+- **`set_value` failure is silent.** A bad value isn't an error; the key just doesn't match, and the token usually ends up in `_default_code` (or, for a bare number, mis-read as the candidate). A typo'd numeric flag can quietly become "the input."
+
+## 7. Quick reference
+
+`delim`: `0` glued (`-t4`) · `' '` next token (`-t 4`) · `c` literal (`-fft+1`). `set_value` fail ⇒ token declined (falls through).
+
+| You want to… | Verb |
+|---|---|
+| A boolean/enum flag setting a field | `check(key, dst, value)` |
+| A flag running code | `check_code(key, fn)` |
+| A numeric option (range-checked, `k`/`M`/… suffixes) | `value_number(key, delim, dst, min, max)` |
+| A string / enum option | `value_string` / `value_enum(…, Enum<V>().add(...))` |
+| An option needing custom parsing | `value_code(key, delim, fn→bool)` |
+| A prefix namespace of sub-keys | `group(key)…end()` |
+| Several values after one key | `list(key, delim, list_delim, fixed?)…end()` |
+| Mutually-exclusive alternatives | `exclusive().ex_case()…end()…end()` |
+| "If this (group) appeared, also set X" | `…end().on_check(dst, value)` |
+| The unmatched-token catch-all | `default_code(fn)` (root) |
+| Read options from a file | `value_code("-ini", ' ', …parse_ini)` |
+| Match-and-ignore a token | `ignore(key)` |
+
+## 8. Open questions / non-coverage
+
+- **The CRTP template plumbing.** The `P`/`R` parameters of `ConfigGroupSetup<P,R>` and the `ConfigKeyGroupSetup`/`ConfigExclusiveSetup`/`ConfigCaseSetup`/`ConfigOptionalSetup` derivations exist purely to keep the fluent chain's return types correct through `end()`. This doc explains the *behavior* (descend/climb); the exact template-instantiation chain is mechanical C++ not re-derived here.
+- **`from_chars` portability.** `config.cpp` has two `from_chars` implementations gated on `CHARCONV` (`std::from_chars` vs. hand-rolled `strtoull`/`strtoll`/`strtod`); the numeric-parsing edge cases (`isnormal` rejection of floats, `ERANGE`) are noted but not exhaustively tabulated.
+- **Exact INI section nesting.** `parse_ini`'s handling of `\`-separated nested section names and the `values[""]`/default-code interplay (`config.cpp:68-79`) is reproduced operationally; the full grammar of valid `.ini` (see `sample.ini`, in the patnashev/prst repo) isn't enumerated.
+- **Per-flag semantics live with the caller, not here.** *What* `-fft +1` or `-check strong count N` means for the run is documented where the chain is declared (the entry-point docs) and where the target field is consumed (`arithmetic-foundation.md` for `GWState`, the test docs for `Options`); this doc covers only the parsing mechanism.

--- a/docs/container-format.md
+++ b/docs/container-format.md
@@ -1,0 +1,135 @@
+# Container format — deep dive
+
+The `.pack` is the framework's optional bundle format, used by PRST's proof system: instead of scattering a proof's many point and product files across the directory, `-proof … pack` writes them all into one append-friendly container. It's the *implementation* behind a contract two other docs only sketch — `proof-system.md` §6 (the `.pack` option) (in the patnashev/prst repo) and `state-serialization.md` §8 (`FilePacked` as the on-disk path). This doc covers how that container is actually laid out and read.
+
+**It is a live path** (grep-confirmed, not dormant): `-proof … pack` constructs a `container::FileContainer` (`prst/src/boinc.cpp:315`, `prst/src/prst.cpp:366`), and the proof system writes its points/products as `FilePacked` files into it (`prst/src/proof.cpp:189,199`; `FilePacked`/`FilePackedWriter` in `file.cpp:385-509`). It's *optional* — a normal `-proof save/build` uses individual `File`s — but when `pack` is requested, this code runs.
+
+> **Scope.** `container.cpp` is ~1,897 lines, including a hand-rolled JSON parser, a base64 codec, and corruption recovery. The class model (from `container.h`) and the **on-disk layout** (from the verified `FileContainer::open` parser) are documented here; the byte-level *writer* framing, the codec internals, and the exact recovery walk are pointed to, not reproduced. External-format risk handled the same way as `curves-and-polynomials.md`: claims are grounded in the header + the parser I read, not inferred from the bodies I didn't.
+
+Source files: `container.h`, `container.cpp`. The `File`-layer bridge: `file.cpp:385-509` (`FilePacked`, `FilePackedWriter`).
+
+Prereqs / companions: `state-serialization.md` (`FilePacked` is a `File` subclass; this is its backend, and a packed file's *payload* is still the `Writer`/`Reader` framing from that doc), `proof-system.md` §6 (the `-proof pack` pipeline — the only consumer).
+
+## 1. The on-disk format
+
+A `.pack` is a sequence of **newline-delimited JSON-array records** (`FileContainer::open`, `container.cpp:1681-1796`):
+
+```
+["PK", 1, …]                         ← header line (≤32 chars): magic + format version 1
+[<chunk_size>, <stream_id>, <codec>] ← chunk record header (≤1023 chars), then <chunk_size> raw bytes
+[<chunk_size>, <stream_id>, <codec>]
+…
+[0, 0]                               ← terminator (a stream-0 chunk of size 0)
+```
+
+- **Header.** `root[0]` is a magic string — `"PK"` (zip-like), `"7f"`, or `"\xD0\x9A"` — and `root[1]` must be `1` (the format version). Anything else ⇒ `EMPTY`.
+- **Chunk records.** Each is a JSON line `[chunk_size, stream_id, optional-codec]` followed by exactly `chunk_size` bytes:
+  - **`stream_id == 0` → an index chunk.** The `chunk_size` bytes are themselves a JSON array of file entries `{file, stream, size, offset, md5}`, which populate the `Index`. A size-0 stream-0 chunk is the **terminator**.
+  - **`stream_id > 0` → a data chunk** for that logical stream. The parser records the chunk's `{offset, size, codec}` and *skips* the bytes (lazy — data is read only when a file is requested). An optional `codec` JSON at `root[2]` says how to decode the chunk (e.g. base64).
+- **Files span streams.** A file's bytes are the concatenation of its stream's data chunks, sliced to `[offset, offset+size)`; `md5` (when present) verifies it. One stream can hold several files (sorted by offset).
+
+Records are **CRLF-terminated** (`\r\n`). The writer side is symmetric and verified: `ChunkedWriteStream::write_chunk` (`container.cpp:834-852`) emits exactly `[buffer_size, stream_id, codec?]\r\n` followed by the raw bytes — the same record `open` parses. Data is buffered up to `MAX_BUFFER_SIZE` (~16 MB) per chunk; the index chunk and the `[0,0]` terminator are emitted by the `Packer` on close (the per-stream terminator in `ChunkedWriteStream::close` is commented out, `:864-865`).
+
+So the format interleaves data chunks with periodic index chunks. **It's append-friendly**: to add files you append more data chunks and a fresh index chunk at the end; on open, a later index entry for a filename **overrides** the earlier one (`open` does `entry.reset()` then reassigns, `container.cpp:1743-1746`). That's how a proof accumulates points into one `.pack` incrementally.
+
+## 2. `FileContainer::open` — the central method
+
+The parser is the authoritative definition of the format. Annotated (`container.cpp:1681-1796`):
+
+```cpp
+int FileContainer::open()
+{
+    // header: a JSON array ["PK"|"7f"|"\xD0\x9A", 1, …]; else EMPTY
+    if (!_stream->readline(st, 32) || !json.parse(st) || !json.root().is_array()
+        || json.root()[0] not a known magic || json.root()[1] != 1) return EMPTY;
+
+    while (true) {
+        // each chunk: [chunk_size, stream_id, codec?]
+        if (!_stream->readline(st, 1023) || !json … size<2 …) return UNEXPECTED_END;
+        int64_t chunk_size = json.root()[0].value_int();
+        int64_t next = _stream->position() + chunk_size;
+        if (next > _stream->length()) return UNEXPECTED_END;
+        int64_t stream_id = json.root()[1].value_int();
+
+        if (stream_id == 0) {                          // index chunk
+            if (chunk_size == 0) break;                //   size 0 = terminator
+            read chunk_size bytes; json.parse(them);   //   a JSON array of file entries
+            for (file : entries) {                     //   {file, stream, size, offset, md5}
+                auto& entry = _index[file["file"]];     //   later entry OVERRIDES earlier
+                entry.stream = file["stream"]; entry.size/offset/md5 = …;
+            }
+        } else {                                       // data chunk for stream_id
+            auto& stream = _streams[stream_id];
+            stream.chunks.push_back({offset: pos, size: chunk_size, codec: root[2]});
+            _stream->set_position(next);               //   skip the bytes (lazy)
+        }
+    }
+
+    // validate: per stream, sort files by offset; flag inconsistent ones → on_corrupted, INDEX_CORRUPTED
+    // offset > 16777215 (one ~16 MB chunk) ⇒ INDEX_CORRUPTED
+    if (_stream->position() < _stream->length()) return EXCESS_DATA;
+    return error;
+}
+```
+
+The return is a `container_error` code: `OK` / `EMPTY` (no/blank/bad-header) / `UNEXPECTED_END` (truncated) / `INDEX_CORRUPTED` (inconsistent entries — `on_corrupted` moves them to `_corrupted` and parsing continues) / `EXCESS_DATA` (trailing bytes past the last chunk). The caller treats `OK` and `EMPTY` as usable (an empty container is fine to append to — `prst/src/boinc.cpp:316`), the rest as corruption to warn about.
+
+## 3. Class model & reference
+
+Three layers in `container.h`:
+
+**JSON** (`:23-116`) — a from-scratch JSON parser/serializer. A `Node` is a `variant<null, value-buffer, array, object>`; objects are a *sorted* `(keys, values)` flat-map (binary-searched `operator[]`/`contains`). Used for every record line and the index. (It's here so the container has no external JSON dependency.)
+
+**Streams** (`:120-339`) — a `ReadStream`/`WriteStream` abstraction with concretes `MemoryStream`, `LimitedReadStream`, `FileStream`, plus the format-specific decorators:
+- `ChunkedWriteStream` — buffers up to `MAX_BUFFER_SIZE` (16,777,200 ≈ 16 MB) then emits a data chunk (`write_chunk`); carries a per-chunk `codec_json`.
+- `Base64CoderStream` / `Base64DecoderReadStream` — the base64 codec a chunk's `codec` field selects.
+
+**Container** (`:222-489`):
+
+| Type | Role |
+|---|---|
+| `FileDesc` | one index entry: `{name, size, stream, offset, md5, data}` |
+| `Index` | a `set<FileDesc>` sorted by name (`contains`/`operator[]` by filename) |
+| `Packer` (+ `Packer::Writer`) | **writes** a container: `add_writer()` → `Writer`; `Writer::add_file(name, …)` → a `WriteStream`; `add_codec`; `md5` flag. Built from a filename, a `WriteStream`, or a `FileContainer`. |
+| `FileContainer` (+ inner `Reader`) | **reads/appends** a container: `open()` parses it; `read_file(filename)` → a `FileDesc` whose `data` `ReadStream` reassembles the stream's chunks and applies codecs; `reopen`/`close`. Holds `_index`, `_streams` (id → `ChunkStream{chunks, files}`), `_corrupted`. |
+| `Unpacker` | a `WriteStream` that dispatches extracted files via an `on_file` callback (the inverse of `Packer`). |
+
+The `File`-layer bridge (`file.cpp`): `FilePacked` is a `File` whose `read_buffer` pulls bytes from `FileContainer::read_file`, and whose `get_writer` returns a `FilePackedWriter` wrapping a `Packer` (`file.cpp:412-487`). So the rest of PRST writes a packed proof point exactly like any other `File` — the container is hidden behind the `File` interface (`state-serialization.md` §3).
+
+## 4. Lifecycle
+
+**Write** (`-proof … pack`): `Proof::init_files` wraps each point/product file as a `FilePacked` over the shared `FileContainer` (`prst/src/proof.cpp:189,199`). Each `File::write` opens a `FilePackedWriter` → a `Packer::Writer` → an `add_file` `WriteStream` (a `ChunkedWriteStream`, optionally base64-coded), writes the framed payload (the same magic/`TYPE`/fingerprint record from `state-serialization.md`), and on close flushes data chunk(s) + updates the index. The container is `close()`d at the end of the run (`prst/src/fermat.cpp:397-398`).
+
+**Read / resume**: constructing the `FileContainer` runs `open()` (§2), building the in-memory `Index` and `_streams`. `read_file(name)` then hands back a `Reader` that lazily concatenates that file's chunks (decoding per the chunk codec) into the `FilePacked` buffer, which the normal `Reader` framing then parses.
+
+**Append**: re-opening for write and adding more files appends new data + index chunks; the override rule (§1) means the newest index wins. This is what lets a long proof grow its `.pack` over many checkpoints.
+
+## 5. Pitfalls
+
+- **`EMPTY` is not an error.** An absent or zero-length or blank-header file returns `container_error::EMPTY`, and callers treat that as "fresh container, fine to append" (`prst/src/boinc.cpp:316` warns only on errors *other* than `OK`/`EMPTY`). Don't treat `EMPTY` as failure.
+- **Later index entries override earlier ones.** A filename appearing in two index chunks resolves to the *last* (`open` resets and reassigns). That's the append mechanism — but it also means a truncated/duplicated append can silently shadow good data; the offset/size validation and MD5 are the guards.
+- **Offsets are bounded by the 16 MB chunk size.** `open` flags `offset > 16777215` as `INDEX_CORRUPTED` — a file's offset is *within* its stream's chunk addressing, not a global file position. Reading the offset as an absolute byte position into the `.pack` is wrong.
+- **Data is read lazily and skipped on open.** `open` records chunk positions and seeks past the bytes; the payload is only materialized on `read_file`. A consumer that assumes `open` validated every byte (beyond the index) is mistaken — MD5 is checked at read time, not open time.
+- **The payload inside a packed file is still the `state-serialization.md` framing.** The container is a *bundling* layer; each entry's bytes are an ordinary magic+appid+`TYPE`+fingerprint record. A `.pack` bug and a checkpoint-format bug are different layers — check which one you're in.
+- **It's a bespoke format with a hand-rolled JSON parser.** Not zip (despite the `"PK"` magic) and not a standard archive — don't point external tools at it. The parser, base64 codec, and recovery are all in `container.cpp`.
+
+## 6. Quick reference
+
+On-disk: newline-delimited JSON records. Header `["PK"|"7f"|"\xD0\x9A", 1, …]`; then `[size, stream_id, codec?]` + `size` bytes per chunk; `stream_id 0` = index (JSON array of `{file,stream,size,offset,md5}`), `>0` = data; `[0,0]` terminates.
+
+| You want… | Where |
+|---|---|
+| Read a packed file | `FileContainer::read_file(name)` → `FileDesc::data` |
+| Write into a container | `Packer::add_writer()` → `Writer::add_file(...)` |
+| The `File`-API bridge | `FilePacked` / `FilePackedWriter` (`file.cpp`) |
+| Enable the `.pack` | `-proof … pack [name]` (`prst/src/prst.cpp:366`, `prst/src/boinc.cpp:315`) |
+| Interpret an open error | `container_error`: `OK`/`EMPTY` usable; `UNEXPECTED_END`/`INDEX_CORRUPTED`/`EXCESS_DATA` = trouble |
+| Add a codec to a chunk | `Writer::add_codec` / `ChunkedWriteStream` `codec_json` (base64) |
+
+## 7. Open questions / non-coverage
+
+- **The `Packer`-level write path.** The *data*-chunk framing is verified (`open` for the reader, `write_chunk` `:834-852` for the writer — they're symmetric). What's *not* traced: how `Packer`/`Packer::Writer::close` emit the **index chunk** and the `[0,0]` terminator, the `add_file` → stream wiring, and flush ordering across writers. Read `Packer` before changing how the index is written.
+- **Codec internals.** The base64 coder/decoder (`Base64CoderStream`/`Base64DecoderReadStream`) and the `codec` JSON schema beyond "base64 selects it" aren't dissected; whether other codecs exist or are planned is unexamined.
+- **Corruption-recovery behavior.** `on_corrupted` (`container.cpp:1798`) moves bad entries to `_corrupted` and parsing continues, but the full recovery walk (what's salvageable, how `_cur_reader`/`_cur_file` interact) was not traced.
+- **The JSON parser.** `JSON::Node::parse` is a hand-rolled parser; its exact grammar/limits (number formats, escaping, the `value-buffer` lazy-parse) are out of scope — treated as "parses the records," not audited.
+- **Concurrency / partial-write durability.** Unlike the local `File` write (atomic `.new`+rename, `state-serialization.md` §5), the container is appended in place; what guarantees hold if the process dies mid-append (beyond the `open`-time corruption codes) wasn't analyzed.

--- a/docs/curves-and-polynomials.md
+++ b/docs/curves-and-polynomials.md
@@ -1,0 +1,103 @@
+# Curves & polynomials — deep dive
+
+The specialized arithmetic that sits *beside* the bignum substrate: elliptic-curve point groups (Edwards, Montgomery), Lucas sequences, and polynomial multiplication — all built on top of `GWNum` (their coordinates *are* `GWNum`s). This is the general-purpose arithmetic library in this repo (`patnashev/arithmetic` serves other tools too), so **most of it is dormant in PRST's own live path** — a fact worth stating plainly up front (verified by grepping callers):
+
+- **`LucasV` / `LucasUV` — LIVE.** The Morrison test's `LucasVMul`/`LucasUVMul` tasks (`exponentiation-algorithms.md` (in the patnashev/prst repo)) drive this arithmetic (`prst/src/lucasmul.cpp`, `prst/src/prst.cpp`), and its small-prime chain indices come from this layer's precomputed differential-addition-chain table. This is the one part PRST actually runs.
+- **Edwards / Montgomery curves — DORMANT.** The ECM cofactor-factoring code is present but its only PRST caller — the probe in `factorize` — is **commented out** (`inputnum.cpp:157-268`; see `inputnum-parsing.md` §6/§8). No live code path instantiates `EdwardsArithmetic`; today it's exercised only by the standalone `arithmetic/test.cpp`.
+- **`PolyMult` / `Poly` — DORMANT (no caller anywhere).** The proof product tree does **not** use it — `ProofBuild` multiplies its residues as `Proof::Product` *giants* via `gw` (`prst/src/proof.cpp:552,663`), not the polynomial engine. `PolyMult` has **no caller anywhere in the repo** — its only mention outside `arithmetic/poly.{h,cpp}` is the `friend class PolyMult;` declaration (`arithmetic/arithmetic.h:229`), not a call — and `arithmetic/poly.cpp` is not even compiled into either build (absent from the linux64 Makefile object list in `prst/src/linux64/Makefile` and the win64 `prst/src/win64/PRST.vcxproj`).
+
+> **Scope and honesty.** This is the largest subsystem by raw volume — `arithmetic/group.cpp` alone is ~42k hand-written lines, and the `.cpp` bodies for the curve/poly/Lucas formulas were **not** read line-by-line for this doc. What follows is an **interface + usage map**: the class hierarchy, which arithmetic each consumer uses, and how chains are built — grounded in the headers. The actual addition/doubling/ladder *formulas* and the polynomial-FFT internals are the mathematics, deferred to `math-and-theorems.md` (in the patnashev/prst repo) and this repo's `docs/mult_*.pdf`s. Treat any formula-level claim as out of scope here, not as verified.
+
+Source files: `arithmetic/group.{h,cpp}` (the group abstraction + chain helpers), `arithmetic/edwards.{h,cpp}`, `arithmetic/montgomery.{h,cpp}`, `arithmetic/lucas.{h,cpp}`, `arithmetic/poly.{h,cpp}`.
+
+Prereqs / companions: `arithmetic-foundation.md` (every coordinate is a `GWNum`; these follow the same `FieldArithmetic`/`FieldElement` strategy pattern, as `GroupArithmetic`/`GroupElement`), `exponentiation-algorithms.md` (`LucasVMul`/`LucasUVMul` are the *tasks*; `LucasV`/`LucasUV` here are the *arithmetic*), `inputnum-parsing.md` (the ECM factoring consumer), `proof-system.md` (in the patnashev/prst repo) (the product-tree consumer), `math-and-theorems.md` (the formulas).
+
+## 1. Two kinds of group arithmetic
+
+Everything here specializes one of two abstract bases in `arithmetic/group.h`, mirroring the `FieldArithmetic`/`FieldElement` pattern from the bignum layer:
+
+- **`GroupArithmetic<Element>`** (`arithmetic/group.h:13`) — a *full* group: `add`, `sub`, `neg`, `dbl`, and scalar `mul` via a windowed NAF chain (`mul(a, W, naf_w, res)`). You can add any two elements.
+- **`DifferentialGroupArithmetic<Element>`** (`arithmetic/group.h:197`) — a *differential* group: `add(a, b, a_minus_b, res)` (addition needs the difference `a−b` as a third input — the Montgomery/Lucas "ladder" property), `dbl`, and scalar `mul` via a differential addition chain. No free `add`; you climb a ladder.
+
+This split is the organizing principle. The five concrete arithmetics:
+
+| Arithmetic | Base | Element | Used for (PRST liveness) |
+|---|---|---|---|
+| `EdwardsArithmetic` | `GroupArithmetic` | `EdPoint` (X,Y,Z,T) | ECM, twisted-Edwards full-group form — **dormant** (§4) |
+| `MontgomeryArithmetic` | `DifferentialGroupArithmetic` | `EdY` (Y,Z) | ECM Montgomery-ladder (y-only) form — **dormant** (test-only) |
+| `LucasVArithmetic` | `DifferentialGroupArithmetic` | `LucasV` (V, parity) | **live**: Morrison's V-only chain (`LucasVMulFast`) |
+| `LucasUVArithmetic` | `GroupArithmetic` | `LucasUV` (U,V, parity) | **live**: Morrison's Gerbicz-checked chain (`LucasUVMul`) |
+| `PolyMult` / `Poly` | — | `Poly` (vector of `gwnum`) | polynomial multiply engine — **no caller anywhere; `arithmetic/poly.cpp` not built** (§4) |
+
+The element types hold their coordinates as `unique_ptr<GWNum>` — e.g. `EdPoint::{X,Y,Z,T}` (`arithmetic/edwards.h:127-130`), `LucasUV::{U,V}` (`arithmetic/lucas.h:264-265`) — so a "point operation" is a handful of `GWArithmetic` mul/add/sub on those `GWNum`s.
+
+## 2. Chain construction — NAF windows and DAC
+
+Scalar multiplication (`point × scalar`) is where the two group kinds diverge, and it's the part this layer most clearly owns:
+
+- **Full groups → windowed NAF.** `get_NAF_W(W, a, res, compress)` (`arithmetic/group.h:10`) decomposes the scalar `a` into a width-`W` non-adjacent form — a signed-digit representation that minimizes nonzero digits — into `res` (a `vector<int16_t>`). `GroupArithmetic::mul(a, W, naf_w, res)` then walks those digits with a precomputed odd-multiples table (the group analogue of `MultipointExp`'s sliding window). Edwards ECM and `LucasUV` use this.
+- **Differential groups → DAC.** A differential addition chain (where every `add` has its difference available) is built from `get_DAC_S_d(e, start, end, maxlen)` plus a baked-in table `precomputed_DAC_S_d[]` of length `precomputed_DAC_S_d_len` (`arithmetic/group.h:192-194`). For a small prime `e`, the chain is looked up in the table; for larger ones it's searched. **This is the source of Morrison's `_dac_index`** — `MorrisonGeneric` precomputes a DAC index per small prime factor (`prst/src/morrison.cpp`) by indexing into `precomputed_DAC_S_d`, and `LucasV`/Montgomery climb the corresponding ladder.
+
+The `DifferentialGroupArithmetic::mul(a, prime, index, res)` overload (`arithmetic/group.h:334`) keys off exactly this: `index < precomputed_DAC_S_d_len` → use the table entry, else compute one via `get_DAC_S_d` (`arithmetic/group.h:347-350`).
+
+## 3. The concrete arithmetics
+
+**`EdwardsArithmetic` / `EdPoint`** (`arithmetic/edwards.h`) — twisted Edwards curves for ECM. `EdPoint` carries extended projective coordinates `(X,Y,Z,T)`; `extend()` materializes `T = X·Y` and projects, `normalize()` reduces to affine. Beyond the group ops it offers the ECM-specific surface: `gen_curve(seed, ed_d)` (generate a pseudo-random curve from a seed), `from_small(...)` (a curve from small integer parameters), `on_curve(a, ed_d)` (membership test), `jinvariant`, `d_ratio`. `ED_PROJECTIVE`/`EDADD_NEGATIVE`/`EDDBL_FOR_EXT_NORM_ADD` are `option` flags into `add`/`dbl`. (`arithmetic/test.cpp` exercises this path: `gen_curve`, `on_curve`, `dbl`/`add`, `mul` with a NAF.)
+
+**`MontgomeryArithmetic` / `EdY`** (`arithmetic/montgomery.h`) — the differential (y-coordinate-only) form, constructed *from* an `EdPoint` (`init(const EdPoint&, EdY&)`) and carrying `(Y,Z)` plus cached `ZpY`/`ZmY`. This is the cheap ladder used for the bulk of ECM scalar multiplication; `add` takes the `a_minus_b` difference, `dbl`, `optimize`.
+
+**`LucasVArithmetic` / `LucasV`** (`arithmetic/lucas.h:9-105`) — the V-only Lucas sequence (differential), parameterized by `negativeQ`. `LucasV` holds `V` (a `GWNum`) and a `parity` bit. This is the arithmetic behind `LucasVMulFast` (the non-checked Morrison chain).
+
+**`LucasUVArithmetic` / `LucasUV`** (`arithmetic/lucas.h:109-268`) — the full `(U,V)` Lucas pair (a full group, so it has `add`/`sub`/`neg` and NAF `mul`), behind the Gerbicz-checked `LucasUVMul`. Notable: a **small-value optimization** — the constructor precomputes a table `_UV_small` of `(U,V,DU)` triples for a small integer `P` (`arithmetic/lucas.h:122-149`), so chains over small `P` avoid full `GWNum` work; `dbl_add_small`/`init_small`/`max_small` use it. Falls back to a `GWNum` `_P`/`_D` for large `P`.
+
+**`PolyMult` / `Poly`** (`arithmetic/poly.h`) — polynomial multiplication over `GWNum` coefficients, wrapping the GWnum `polymult` library (`pmhandle`). `Poly` is a vector of `gwnum` with a `monic` flag and an optional preprocessed `_cache`. `PolyMult` offers a full toolkit: `mul`, `mul_split`, `mul_range`, `mul_twohalf`, `fma_range`, `reciprocal`, `preprocess`(+`preprocess_and_mul`), `eval`. **It has no caller anywhere in the repo** — the proof BUILD product tree multiplies *giants* (`Proof::Product`, `prst/src/proof.cpp`), not polynomials; nothing in the tree names `PolyMult` except the `friend class PolyMult;` declaration (`arithmetic/arithmetic.h:229`), and `arithmetic/poly.cpp` is not even built (it is absent from the linux64 `prst/src/linux64/Makefile` object list and the win64 `prst/src/win64/PRST.vcxproj`). It is dormant code in this repo, available for the arithmetic library's other consumers.
+
+## 4. Usage: who actually calls this
+
+Only one consumer is live in PRST; the rest is dormant-but-present (grep-verified above). Stated honestly:
+
+1. **Morrison — the one live consumer** (`prst/src/morrison.cpp` + `prst/src/lucasmul.cpp`, reached from `prst/src/prst.cpp`). `LucasVMulFast`/`LucasUVMul` advance `LucasV`/`LucasUV` state; small odd primes are multiplied via the DAC ladder, with `MorrisonGeneric` precomputing the chain index per small prime (the `_dac_index` array) from `precomputed_DAC_S_d`. The Gerbicz-checked variant uses the full `LucasUV` group. This is the part of the layer PRST runs in production.
+2. **ECM factoring — dormant.** The elliptic-curve method *would* pick a pseudo-random Edwards curve (`gen_curve`), use the Montgomery ladder for the bulk scalar-multiply, and read a factor from a non-trivial `gcd` of a coordinate with `N` — but the code that does this is the **commented-out** block in `InputNum::factorize` (`inputnum.cpp:157-268`). The live `factorize` is trial-division only (`inputnum-parsing.md` §6). So the curve arithmetic is present and unit-tested (`arithmetic/test.cpp`) but not wired into any live PRST run.
+3. **`PolyMult` / `Poly` — dormant, no caller anywhere.** The proof product tree does *not* use this layer: `ProofBuild` compresses proof points by multiplying *giants* (`Proof::Product`, `prst/src/proof.cpp:552,663` via `gw`), not the `PolyMult` polynomial engine — a natural assumption that the grep refutes. In fact `PolyMult` has **no caller anywhere in the repo**: its only mention outside `arithmetic/poly.{h,cpp}` is the `friend class PolyMult;` declaration (`arithmetic/arithmetic.h:229`), and `arithmetic/poly.cpp` is not even compiled into either build (absent from the linux64 `prst/src/linux64/Makefile` object list and the win64 `prst/src/win64/PRST.vcxproj`).
+
+Where it *is* used (Morrison, and the dormant curve/poly code), the *coordinates/coefficients* are `GWNum`s in the same `GWState` FFT the test runs in — so this layer is "structured arithmetic on top of the one modular-multiply engine," not a separate number system.
+
+## 5. Common patterns
+
+- **Coordinates are `GWNum`s, ops are `GWArithmetic` calls.** Every `EdwardsArithmetic::add`/`dbl`, every `LucasUVArithmetic::mul` is, underneath, a sequence of `gw().mul`/`square`/`add` on the element's coordinate `GWNum`s — so the round-off / reliability machinery and the FFT config all come from `arithmetic-foundation.md` unchanged.
+- **Full vs differential is a real fork, not a style.** A `GroupArithmetic` lets you `add` anything (Edwards, `LucasUV`); a `DifferentialGroupArithmetic` only lets you `add(a,b,a−b)` and so forces a ladder (Montgomery, `LucasV`). Choosing the differential form trades generality for ~half the work — which is why Morrison's cheap path uses `LucasV` and ECM's bulk uses the Montgomery ladder.
+- **NAF for full, DAC for differential.** Two distinct scalar-multiply chain builders (`get_NAF_W` / `get_DAC_S_d`+table), picked by which group kind you're in.
+- **Small-integer fast paths.** `LucasUVArithmetic`'s `_UV_small` table and the `precomputed_DAC_S_d` table both hard-code chains for small operands to skip full `GWNum` arithmetic.
+
+## 6. Pitfalls
+
+- **This doc maps the surface, not the formulas.** The curve addition/doubling, the Montgomery ladder, the Lucas recurrences, the NAF/DAC construction, and the polynomial FFT all live in `.cpp` bodies (notably ~42k lines of `arithmetic/group.cpp`) not walked here. Don't treat the descriptions above as a substitute for reading the relevant `.cpp` before modifying a formula — and cross-check the math against `math-and-theorems.md`/the PDFs.
+- **`EdPoint` coordinates may be null / unextended.** `X/Y/Z/T` are `unique_ptr<GWNum>`; `Z`/`T` can be absent until `extend()`/`normalize()`. Code reading `*T` without ensuring extension will dereference null.
+- **Differential `add` needs the *right* difference.** `add(a, b, a_minus_b, res)` is only correct when `a_minus_b` truly equals `a−b` on the ladder; feeding the wrong difference silently computes garbage (no error — it's not checked).
+- **`MorrisonGeneric`'s `_dac_index` encodes table-hit vs. computed by *sign*.** For a small prime found in `precomputed_DAC_S_d` it stores the table *position* (positive); for a prime beyond the table it stores `-get_DAC_S_d(...)` — the **negative** of a freshly-computed chain parameter (`prst/src/morrison.cpp`). It is *not* an "index ≥ len means compute" scheme; the sign is the discriminator (`arithmetic/group.h`'s differential `mul` reads the table for a positive in-range index, else takes the value inline). A wrong value builds the wrong differential chain — a correctness bug, not just a perf one.
+- **`Poly` ownership is subtle.** A preprocessed `Poly` holds a `_cache` instead of `_poly`; `size()`/`data()` switch on `_cache != nullptr`. Mixing preprocessed and raw polynomials, or freeing across a `PolyMult`, needs care (the move/copy go through `PolyMult`).
+
+## 7. Quick reference
+
+| You want… | Class / call |
+|---|---|
+| A fast full elliptic-curve group (ECM) | `EdwardsArithmetic` / `EdPoint` |
+| The cheap EC ladder (ECM bulk) | `MontgomeryArithmetic` / `EdY` |
+| A random ECM curve from a seed | `EdwardsArithmetic::gen_curve(seed, ed_d)` |
+| Morrison's V-only chain | `LucasVArithmetic` / `LucasV` |
+| Morrison's checked U-V chain | `LucasUVArithmetic` / `LucasUV` |
+| Multiply a point by a scalar (full group) | `get_NAF_W` → `mul(a, W, naf_w, res)` |
+| …by a small prime (differential) | `precomputed_DAC_S_d[index]` → ladder `mul` |
+| Polynomial multiply (this repo's engine; no caller anywhere, `arithmetic/poly.cpp` not built) | `PolyMult` / `Poly` |
+
+(The proof product tree multiplies *giants* (`Proof::Product`), not polynomials — see §4. ECM/curve rows above are dormant in PRST today — §4.)
+
+Two group kinds: **full** (`GroupArithmetic`: `add`/`sub`/`neg`/`dbl` + NAF `mul`) vs **differential** (`DifferentialGroupArithmetic`: `add(a,b,a−b)`/`dbl` + DAC `mul`). All coordinates are `GWNum`s.
+
+## 8. Open questions / non-coverage
+
+- **All the formulas.** Edwards/Montgomery point addition & doubling, the j-invariant and `gen_curve` construction, the Lucas `V`/`U` recurrences, the NAF and DAC chain algorithms, and the polynomial-FFT (`polymult`) internals — the actual mathematics — are deferred to `math-and-theorems.md` and `docs/mult_*.pdf`. This doc deliberately stops at the interface.
+- **`arithmetic/group.cpp` (~42k lines) is unread here.** A line-level deep-dive of the group arithmetic would be its own (large) effort; what's documented is the public surface from `arithmetic/group.h` plus the consumers. If a curve/ladder bug surfaces, that file is the next stop.
+- **ECM strategy and parameters.** *Which* curves/bounds the factorizer tries, stage-1/stage-2 structure, and the (currently commented-out) deeper ECM probe in `inputnum.cpp`'s `factorize` are factoring-strategy questions touched in `inputnum-parsing.md` §6/§8, not re-derived here.
+- **`polymult` library boundary.** `PolyMult` wraps GWnum's `polymult` (`pmhandle`, `polymult.h`) — like `gwnum` itself, a prebuilt component understood at its API, not dissected (cf. `arithmetic-foundation.md`'s external-library note).
+- **The proof product tree is not in this layer.** `ProofBuild` multiplies `Proof::Product` *giants* via `gw` (`prst/src/proof.cpp`), not `PolyMult` — its schedule is `proof-system.md` territory and bottoms out in the bignum layer, not here. (Noted because "polynomial product tree" is the natural-but-wrong assumption.)

--- a/docs/inputnum-parsing.md
+++ b/docs/inputnum-parsing.md
@@ -1,0 +1,254 @@
+# InputNum parsing — deep dive
+
+`InputNum` is the parsed candidate. `main()` hands it a string like `"30006!4-1"`, `"5*2^100+1"`, `"Phi(3,10^20)"`, or `"(2^257-1)/535006138814359"`, and `InputNum::parse` turns it into a structured form: a *type* (`KBNC` / `FACTORIAL` / `PRIMORIAL` / `GENERIC`), the components `k`, `b`, `n`, `c`, an optional divisor `F`, a partial factorization of `N∓1`, and a pretty-printed display string. **`Run::create` dispatches almost entirely off this structure** (`input.type()`, `input.c()`, `input.n()`, `input.factors().size()`, `input.is_half_factored()`), so "the wrong test was selected" bug reports almost always trace back here.
+
+Two things make this module trickier than a parser has any right to be:
+
+1. **Classification is not purely syntactic.** `parse` produces a *tentative* type — it already collapses the trivial `k*b^n+c` shape (`k=1, n=1, /1`) to `GENERIC` at `inputnum.cpp:959-963` — then `process()` re-derives the rest: it can absorb a `k` divisible by `b` into the exponent, and detect Fermat / cyclotomic / quadratic / hexic structure on a `KBNC` candidate (`process` never promotes a plain/`GENERIC` number; the algebraic-detection block at `inputnum.cpp:1059` is gated on `_type==KBNC`). The type a user sees reported is the *post-`process`* type, not the one the tokens suggested.
+2. **Factorials and primorials are stored as negative `Giant`s.** A factor list entry with `factor.first < 0` is a *pseudo-factor*: a packed encoding of `n!` or `n#` that `expand_factors()` later expands into real primes. Code that walks `_factors` and forgets to check the sign will multiply garbage.
+
+Source files:
+- `inputnum.h` (the class, type constants, accessors)
+- `inputnum.cpp` (the parser, `process`, `setup`, `mod`/fingerprint, `factorize`, `expand_factors`)
+
+Prereqs / companions: `run-hierarchy.md` (in the patnashev/prst repo) (the consumer — `Run::create` keys off `type()`/`c()`/`factors()`/`is_half_factored()`/`expand_factors()`), and `state-serialization.md` (future; `read`/`write` use the `File` `Reader`/`Writer`).
+
+## 1. The data model
+
+Type constants (`inputnum.h:13-22`):
+
+```cpp
+static const int ZERO = 0;
+static const int GENERIC = 1;
+static const int KBNC = 2;
+static const int FACTORIAL = 3;
+static const int PRIMORIAL = 4;
+
+static const int ALGEBRAIC_SIMPLE = 0;
+static const int ALGEBRAIC_CYCLOTOMIC = 1; //     X^3 -+ 1 = (X^2 +- X + 1)(X -+ 1)
+static const int ALGEBRAIC_QUAD = 2;       //  1/4 X^4 + 1 = (1/2 X^2 + X + 1)(1/2 X^2 - X + 1)
+static const int ALGEBRAIC_HEX = 3;        // 1/27 x^6 + 1 = (1/3 X^2 + X + 1)(1/3 X^2 - X + 1)(1/3 X^2 + 1)
+```
+
+The private state (`inputnum.h:94-114`), with what each field holds:
+
+| Field | Meaning |
+|---|---|
+| `_type` | `ZERO`/`GENERIC`/`KBNC`/`FACTORIAL`/`PRIMORIAL`. The *raw* type; `type()` overrides it to `GENERIC` when a divisor `_gf ≠ 1` is present. |
+| `_gk`, `_gb` | `k` and `b` as `Giant`s (arbitrary precision). For `FACTORIAL`/`PRIMORIAL`, `_gb` is the *computed* `n!`/`n#` value. |
+| `_n` | the exponent (or the factorial/primorial argument). |
+| `_c` | the additive constant (`int64_t`; `\|c\|` capped at 63 bits during parse). |
+| `_gf` | the divisor `F` from a `(<expr>)/F` cofactor form; `1` when absent. |
+| `_factors`, `_cofactor` | the partial factorization of the quantity the deterministic test needs (`N-1` for `c=+1`, `N+1` for `c=-1`), plus the unfactored remainder. **Entries may be negative pseudo-factors** (see §6). |
+| `_b_factors`, `_b_cofactor` | the factorization of `b` itself (KBNC only). `_factors` is seeded from these times `_n`. |
+| `_custom_k/_b/_d/_f` | display overrides — the literal text the user typed, so the echo reads `Phi(3,10^20)` rather than the expanded integer. |
+| `_gfn` | if `N` is a Fermat number `b^(2^gfn)+1`, the exponent; else `0`. |
+| `_multifactorial` | the multifactorial step `m` (`n!m`); `1` for an ordinary factorial. |
+| `_algebraic_type`, `_algebraic_k` | the detected algebraic form and its small parameter `k`; drive the `setup()` known-factors trick (§6). |
+
+`N` itself is never stored as a field; it's recomputed on demand by `value()` (`inputnum.h:70`):
+
+```cpp
+arithmetic::Giant value() { return _type == GENERIC ? _gb : _type != KBNC ? (_gk*_gb + _c)/_gf : (_gk*power(_gb, _n) + _c)/_gf; }
+```
+
+So `GENERIC` *is* `_gb`; `FACTORIAL`/`PRIMORIAL` are `(k·b + c)/F` (with `_gb` the precomputed factorial); `KBNC` is `(k·b^n + c)/F`.
+
+## 2. `parse` — the central function
+
+`InputNum::parse` (`inputnum.cpp:504-993`) is ~490 lines. It runs in three movements; the line ranges below are the map.
+
+**(a) Tokenize** (`:523-543`). A `Token` (`:385-457`) is either an operator (`+ - * / ^ ! #`) or an `Expr` (`:271-383`) — a number, an `name(args)` function call, or a parenthesized `()` sub-expression. The whole string is lexed into a `tokens` vector; leftover non-space input after the optional closing quote is `"excess symbols"`.
+
+**(b) Pick a top-level shape.** In priority order:
+
+- **Cofactor-divisor `(<expr>)/F` → GENERIC** (`:546-639`). Only taken when the first token is a `()` expression *and* every following operator is `/` with an `Expr` operand (the look-ahead loop at `:549-562`). It recursively `parse`s the inner expression, multiplies all the divisors into `gf`, checks `recursive.value() % gf == 0` (else `"not divisible"`), copies the recursive result's fields, and **leaves `_gf` set** so `type()` will report `GENERIC`. This is why `(2^257-1)/53500…` is tested with a plain probabilistic Fermat test, not a Pocklington test.
+
+  ```cpp
+  if (it_expr->expr && it_expr->expr->str_func == "()")
+  {
+      bool bf = false;
+      auto itF = it_oper;
+      while (itF != tokens.end() && itF->oper == '/')   // every following op must be '/'
+      {
+          itF++;
+          if (itF == tokens.end() || !itF->expr) { bf = false; break; }
+          bf = true;
+          itF++;
+      }
+      if (itF != tokens.end()) bf = false;              // ...and nothing else after
+      if (bf) { /* recursive parse, accumulate gf, copy fields, keep _gf */ }
+  }
+  ```
+
+- **`Phi(3,x)` / `Phi(6,x)`** (`:644-689`) and **`Quad(x)` / `Hex(x)`** (`:690-756`) — algebraic constructors. Each recursively parses its argument as `…+1`, derives `k`, sets `c = 1`, and records `_algebraic_type`/`_algebraic_k` when the small `k` is in range (`Phi`: `k<1000`; `Quad`: `k<100`; `Hex`: `k<32`). `Phi(6,x)` is `Phi(3,-x)`; a leading `-` in the argument flips 3↔6 (`:651-655`).
+
+- **The `k*b^n+c` walk** (`:761-966`) — the common path. It is a hand-rolled left-to-right scan, not a precedence parser:
+  1. A `*` chain accumulates the `k` factors (`:764-793`), merging each operand's factorization with power `+1`.
+  2. The next `Expr` is `b`; an optional `^n` sets the exponent (`:802-833`); `b`'s factorization is merged into `_factors` with power `n`.
+  3. `!` → `FACTORIAL` (with a following `!`-run or a second arg giving the multifactorial step) (`:835-866`); `#` → `PRIMORIAL` (`:867-885`). Both compute `_gb` via the `factorial()`/`primorial()` helpers and push a negative pseudo-factor.
+  4. A `/d` run divides out cofactors, merging with power `−1` and checking divisibility (`:899-931`).
+  5. A trailing `+c` / `-c` sets `c` (`:943-958`); `\|value\|` over 63 bits is `"C too big"`.
+  6. **The GENERIC fallback** (`:959-963`): if there's no constant and the shape is the trivial `k=1, n=1, /1`, the type degrades to `GENERIC` (it's just a bare number or expression):
+     ```cpp
+     else if (it_oper == tokens.end() && type == KBNC && gk == 1 && n == 1 && gd == 1)
+     {
+         type = GENERIC;
+         n = 0;
+     }
+     else if (c_required)
+         return InputNum::ParseResult(false, …, "C expected");
+     ```
+
+**(c) Commit + `process`** (`:972-992`). The locals are moved into the members, `_factors` is sorted (positive-power factors first, then by value, `:989`), and `process(gd, true)` finishes classification. `parse` returns a `ParseResult` (`inputnum.h:24-35`) carrying `success`, an error `pos`, and a `message` — the `pos` is what lets `main()` point a caret at the offending character.
+
+Note the `c_required` parameter: top-level parses require a trailing `±c` (default `true`). The recursive parses for the `p(index)` function (`:298`) and `(…)` sub-expressions (`:321`) pass `c_required = false`, so a bare expression is legal there. `Phi`/`Quad`/`Hex` don't use that flag — they *append* `"+1"` to the argument before recursing (`:657, :703`), guaranteeing a constant; and the cofactor-divisor inner parse (`:566`) uses the default, relying on the user's inner expression to carry its own `±c`.
+
+## 3. Field & method reference
+
+The accessors are where the non-obvious overrides live. Every public method (`inputnum.h:56-87`):
+
+| Method | Returns / note |
+|---|---|
+| `empty()` | `_gb == 0` — nothing parsed yet. |
+| `type()` | `_gf == 1 ? _type : GENERIC` — **a divisor form always reports `GENERIC`**, regardless of the inner shape. |
+| `k()` | `k` as `uint64_t`, or **`0` if it doesn't fit in ≤52 bits / 2 limbs**. Callers that test `k() == 1` must know a huge `k` reads as `0`. |
+| `b()` | `b` as `uint32_t`, or `0` if `>1` limb. (`Run::create`'s Proth check tests `b() == 2`; a giant base reads as `0`.) |
+| `n()` | `_n`, but `1` when `GENERIC`. |
+| `c()` | `_c`, but `0` when `_gf ≠ 1`. |
+| `f()` | `F` as `uint32_t` (0 if multi-limb). |
+| `gk()`, `gb()`, `gf()` | the full-precision `Giant&`s. |
+| `gfn()` | Fermat-number exponent, `0` if not a Fermat number. |
+| `multifactorial()` | the `!m` step. |
+| `algebraic_type()`, `algebraic_k()` | the detected algebraic form. |
+| `value()` | recomputes `N` (see §1). Allocates — don't call it in a hot loop. |
+| `mod(m)` | `N mod m` computed from the factor structure without materializing `N` (§5). |
+| `fingerprint()` | `mod(3417905339)` — the 32-bit checksum (§5). |
+| `bitlen()` | bit length of `N`, computed cheaply from `k`/`b`/`n`/`F` and only materialized when `≤ 64` (`:1390-1404`). |
+| `is_half_factored()` | the BLS gate `Run::create` uses (§5). |
+| `add_factor(g)` | move a factor from a cofactor into the factored list (used when an external sieve supplies a factor). |
+| `b_factors()`, `b_cofactor()`, `factors()`, `cofactor()` | the factorization views. `factors()`/`cofactor()` are what `Run::create` and the deterministic tests read. |
+| `factorize_minus1(depth)`, `factorize_small()` | trial-division helpers returning small divisor lists. `factorize_small` feeds trial division (`prst/src/prst.cpp:295,312`) and `-batch` (`prst/src/batch.cpp:261,278`); `factorize_minus1` feeds the proof security seed (`prst/src/proof.cpp:104`). |
+| `expand_factors()` | expand factorial/primorial pseudo-factors into primes (§6). |
+| `input_text()`, `display_text()` | the echoed forms; `display_text()` is elided to ~30 chars. |
+
+## 4. Lifecycle: parse → process → setup
+
+The pipeline a candidate flows through:
+
+1. **`parse(s)`** → tentative type, components, partial factorization, then calls…
+2. **`process(gd, factored)`** (`inputnum.cpp:1002-1217`) — the classifier. It:
+   - (if not already factored) factorizes `_gk` and, for `KBNC`, `_gb`, seeding `_factors` from `_b_factors × _n` (`:1013-1056`); folds the divisor `gd` in with negative powers.
+   - sorts `_factors` and rolls `_b_cofactor^n` into `_cofactor` (`:1037-1041`).
+   - **detects algebraic structure** for `KBNC, c=1, gd=1, ALGEBRAIC_SIMPLE` (`:1059-1108`): a Fermat-number exponent `_gfn` when `k=1` and `n` is a power of two (`:1061-1062`); then, when `\|bitlen(k) − log2(b)·n\|` is small, it computes `b^n − k` and tags `ALGEBRAIC_CYCLOTOMIC` (`±1`), or `b^n/2 − k` → `ALGEBRAIC_QUAD`, or `b^n/3 − k` → `ALGEBRAIC_HEX`.
+   - normalizes the representation: reduces a common GCD of `b`'s exponents into `n` (`:1115-1132`), absorbs a `k` divisible by `b` into `n` (`:1134-1139`), and works the divisor `gd` back through `k`/`b` (`:1142-1214`).
+   - rebuilds `_input_text` and `_display_text` via `build_text` (`:1219-1306`).
+3. **`setup(GWState&)`** (`inputnum.cpp:1308-1388`) — hands the number to GWnum. For an algebraic form it sets `state.known_factors` to the algebraic cofactor and configures GWnum modulo a *fast-form multiple* of the candidate (e.g. cyclotomic uses `k³·b^(3n) ± 1`, `:1320-1325`). GWnum then divides the known factor out (`arithmetic/arithmetic.cpp:76-79`: `*N /= known_factors`), leaving the candidate as the working modulus. The payoff is **FFT speed**, not size: GWnum's irrational-base transform is fastest on the special `k·b^n±c` shape, and the fast-form multiple is actually *larger* than the candidate (§6). After setup it verifies `state.fingerprint == fingerprint()` (or `*state.N % 3417905339 == fingerprint()`), throwing `ArithmeticException` on mismatch.
+
+`read`/`write` (`inputnum.cpp:21-47`) are the checkpoint path: `read` always produces a `GENERIC` number from the stored `Giant`; `write` stores the numerator `k·b^n + c` directly (note: *not* divided by `_gf` — for the common `_gf == 1` case that equals `value()`).
+
+There's also a **recursion** dimension: `parse` constructs throw-away `InputNum`s for sub-expressions (`(…)`, `Phi`/`Quad`/`Hex` arguments, the `p(index)` prime function at `:289-315`). Each recursive `parse`/`process` runs the full pipeline on the fragment, then the parent splices the fields in.
+
+## 5. `mod` / fingerprint / `is_half_factored`
+
+**`mod(modulus)`** (`inputnum.cpp:1433-1501`) computes `N mod m` *without* building `N`. For `KBNC` it multiplies the residues of `_cofactor` and each factor `p^e` (binary exponentiation of the per-factor residue, with reductions to keep products in 64 bits), then applies `+c` and divides by `F` via a modular inverse (`f_inv`). If `F` isn't invertible mod `m` it falls back to `value() % m`.
+
+**`fingerprint() = mod(3417905339)`** (`inputnum.h:72`) is a checksum against a fixed 32-bit modulus (`3417905339`, ≈ `0.8·2³²`). It's used purely as a *sanity check*: `setup` recomputes the residue of the modulus GWnum actually built and throws if it disagrees with `fingerprint()`. It also namespaces checkpoint filenames (`File::unique_fingerprint(input.fingerprint(), …)` throughout the test classes). It is **not** cryptographic and not collision-free — see Pitfalls.
+
+**`is_half_factored()`** (`inputnum.cpp:1503-1519`) is the BLS "more than half of `N∓1` is factored" gate that `Run::create` calls before committing to a deterministic Pocklington/Morrison test:
+
+```cpp
+bool InputNum::is_half_factored()
+{
+    if (std::abs(c()) != 1)
+        return false;
+    if (_cofactor.empty() || _cofactor.bitlen()*2 + 10 < bitlen())
+        return true;
+    if (_cofactor.bitlen()*2 > bitlen() + 10)
+        return false;
+    Giant tmp;
+    tmp = 1;
+    for (auto& factor : _factors)
+        tmp *= power(factor.first, factor.second);
+    if (_c == 1)
+        return tmp > _cofactor;
+    tmp -= 1;
+    return tmp > _cofactor;
+}
+```
+
+The cheap bit-length bounds short-circuit the common cases; only the ambiguous middle band materializes the factored product. (Note this multiplies `_factors` directly — it relies on the pseudo-factors having already been expanded by `Run::create`'s `expand_factors()` call, since this runs *after* it on the deterministic path.)
+
+## 6. Algebraic factoring & the negative-`Giant` factor encoding
+
+**Algebraic forms.** GWnum is fastest on the special shape `k·b^n±c` (an irrational-base discrete weighted transform). A candidate such as `Phi(3,b^n) = (b^(3n) − 1)/(b^n − 1)` isn't of that shape, but it *divides* one that is. PRST recognizes the form (explicitly via `Phi`/`Quad`/`Hex` syntax in `parse`, or implicitly via the `b^n − k ≈ ±1` test in `process`) and, in `setup`, configures GWnum modulo the fast-form multiple and supplies the known algebraic factor via `state.known_factors`, which GWnum divides out — leaving the candidate as the working modulus while keeping the fast FFT. The multiple is **larger** than the candidate; the win is FFT efficiency, not a smaller number. The four cases and the fast-form multiple each sets up (`inputnum.cpp:1318-1349`):
+
+| `_algebraic_type` | Recognized form | GWnum fast-form multiple |
+|---|---|---|
+| `ALGEBRAIC_CYCLOTOMIC` | `Phi(3/6, …)`, or `b^n − k = ±1` | `k³·b^(3n) ± 1` |
+| `ALGEBRAIC_QUAD` | `Quad(…)`, or `b^n/2 − k = ±1` | `k⁴·b^(4n)/4 + 1` (parity-adjusted) |
+| `ALGEBRAIC_HEX` | `Hex(…)`, or `b^n/3 − k = ±1` | `k⁶·b^(6n)/27 + 1` (parity-adjusted) |
+
+If GWnum falls back to a general modulus (`GENERAL_MOD`/`GENERAL_MMGW_MOD`) — i.e. the fast form bought nothing — `setup` abandons the trick, resets to `ALGEBRAIC_SIMPLE`, and re-runs on the full number (`:1352-1359`).
+
+**Factorials and primorials as negative `Giant`s.** This is the encoding most likely to bite. When `parse` hits `!` or `#`, it builds a *negated* small `Giant` and pushes it as a factor:
+
+```cpp
+// factorial n!m  (inputnum.cpp:861-865)
+Giant factor;
+factor = ((uint64_t)multifactorial << 32) + n;  // limb0 = n, limb1 = m
+factor.arithmetic().neg(factor, factor);         // store NEGATED
+gb = factorial(factor);
+::add_factor(factors, factor, 1);
+
+// primorial n#  (inputnum.cpp:875-879)
+Giant factor;
+factor.arithmetic().neg(it_expr->expr->value, factor);  // negated n
+gb = primorial(factor);
+n = factor.data()[0];
+::add_factor(factors, factor, 1);
+```
+
+So a factor-list entry with `factor.first < 0` is a *pseudo-factor*: a one-limb negated value is `n#` (primorial), a two-limb negated value is `n!m` (factorial, `data()[0]=n`, `data()[1]=m`). The `factorial()` / `primorial()` free functions (`:459-502`) decode and compute the actual product. **`expand_factors()`** (`:1545-1606`) is what turns these into real primes — it sieves every prime up to `n` (or every multifactorial term), accumulates exponents into a `map`, and rebuilds `_factors`. `Run::create` calls it right before the half-factored test, which is why the deterministic-test path sees expanded primes while the raw parse result still carries the compact pseudo-factor.
+
+**The `factorize` sieve** (`inputnum.cpp:96-269`) is the workhorse behind both `process` and the `factorize_*` helpers. It pulls out the power of two, then runs a segmented bit-sieve of small primes up to roughly `2^(2s)` (default `s=10`), trial-dividing `N` and moving the unfactored remainder to `cofactor`. An optional `is_factor` predicate lets callers substitute a cheaper test — e.g. `factorize_minus1` passes `mod(p) == 1` so it can find factors of `N−1` without computing `N−1` (`:1529`).
+
+## 7. Pitfalls
+
+- **A `(<expr>)/F` form is always `GENERIC`.** `type()` returns `GENERIC` whenever `_gf ≠ 1` (`inputnum.h:57`), so `Run::create` routes every cofactor-divisor candidate to a probabilistic Fermat test — never Proth, Pocklington, or Morrison — no matter how nicely the inner expression factors. If a user expects a deterministic test on `(b^n−1)/F`, this is why they don't get one.
+- **`k()` / `b()` / `f()` silently return `0` for multi-limb values.** They're convenience narrowings (`inputnum.h:58-62`). `Run::create`'s `input.b() == 2` and `log2(input.gk()) < input.n()` mix the narrow and wide accessors deliberately; new dispatch code must not assume `k()`/`b()` reflect the true magnitude.
+- **Negative entries in `factors()` are pseudo-factors, not real factors.** Anything iterating `_factors` (a GCD product, a residue computation) must either run after `expand_factors()` or guard `factor.first < 0`. `mod`, `is_half_factored`, and `print_info` all assume expansion has happened on the deterministic path.
+- **`type()` is post-`process`, not what the tokens said.** `parse` collapses the trivial `KBNC` shape to `GENERIC` (`inputnum.cpp:959-963`); `process` then can absorb `k` divisible by `b` into `n`, reduce a common exponent GCD, or tag an algebraic form (`process` itself never touches `_type`). Reason about the *reported* type, not the literal input.
+- **`fingerprint()` is a 32-bit non-cryptographic checksum.** It guards against a GWnum mis-setup (wrong FFT, wrong modulus) and namespaces files; it is not collision-resistant. Don't treat a fingerprint match as proof two inputs are equal, and don't widen its role without revisiting every `File::unique_fingerprint` caller (a checkpoint-format concern — see `state-serialization.md`).
+- **The algebraic `setup` trick mutates state and can self-disable.** On a GWnum general-modulus fallback, `setup` resets `_algebraic_type`/`_algebraic_k` to simple and recurses (`:1352-1359`). Code reading `algebraic_type()` after `setup` may see a different value than before it.
+
+## 8. Quick reference
+
+| Input syntax | Parsed `type()` | Notes |
+|---|---|---|
+| `123456789` | `GENERIC` | bare number; `value() == _gb` |
+| `5*2^100+1` | `KBNC` | `k=5, b=2, n=100, c=1` (Proth-eligible) |
+| `2^257-1` | `KBNC` | `k=1, b=2, n=257, c=-1` |
+| `100!-1` / `100!2-1` | `FACTORIAL` | `_gb = 100!` (or `100!!`); negative pseudo-factor in `_factors` |
+| `100#+1` | `PRIMORIAL` | `_gb = 100#`; negative pseudo-factor |
+| `(2^257-1)/535006…` | `GENERIC` | divisor form; `_gf ≠ 1` ⇒ always `GENERIC` ⇒ probabilistic Fermat test |
+| `Phi(3,10^20)` | `KBNC` | cyclotomic; `_algebraic_type = CYCLOTOMIC` |
+| `Quad(10^20)` / `Hex(…)` | `KBNC` | `_algebraic_type = QUAD` / `HEX` |
+| `p(1000000)` | (as recursed) | the 1,000,000th prime; capped at index 105097565 |
+
+| You want to… | Call |
+|---|---|
+| Get the integer `N` | `value()` (allocates) |
+| Cheaply test size | `bitlen()` |
+| Compute `N mod m` without building `N` | `mod(m)` |
+| Know which test will run | inspect `type()`, `c()`, `n()`, `factors().size()`, then `expand_factors()` + `is_half_factored()` — exactly what `Run::create` does |
+| Expand `n!`/`n#` factors to primes | `expand_factors()` |
+| Echo the user's input / a short form | `input_text()` / `display_text()` |
+
+## 9. Open questions / non-coverage
+
+- **The commented-out ECM/Fermat-probe block** in `factorize` (`inputnum.cpp:157-268`) sketches an Edwards-curve ECM stage and a base-3 Fermat probe on the cofactor. It's dead today; if a future version wants deeper automatic factoring of `b`'s cofactor, this is the seam. Not covered here beyond noting it exists.
+- **`build_text` display logic** (`:1219-1306`) — the elision, the `_custom_*` overrides, the factorial/primorial/divisor formatting — is faithfully reproduced output formatting, not algorithm. Treated as a black box; read it directly if a display bug is reported.
+- **The exact `factorize` sieve schedule** (segment sizing, the `s`/`j` growth at `:130-147`) is a performance-tuned trial-division bound. The contract is "small factors out, remainder in `cofactor`"; the schedule itself is a tuning parameter not audited here.
+- **The GWnum `setup` math** (FFT selection, `known_factors`, `force_mod_type`) belongs to the GWnum/`GWState` layer; this doc covers only how `InputNum` *chooses* the modulus and verifies it via the fingerprint. See the GWnum notes referenced in lay-of-the-land (in the patnashev/prst repo)'s open questions.
+- **`print_info`** (`:1635-1942`) is the `-info` diagnostic dump (small factors, algebraic factor display, N∓1 factor fractions, Kronecker symbols). It's reporting, not parsing; covered only in passing.

--- a/docs/lay-of-the-land.md
+++ b/docs/lay-of-the-land.md
@@ -1,0 +1,126 @@
+# Arithmetic Framework — Lay of the Land
+
+A high-level orientation to this library for contributors new to the codebase. This repo
+(`patnashev/arithmetic`) is the **shared arithmetic framework**: the bignum, arithmetic, checkpointing,
+logging, and option-parsing primitives that higher-level tools reuse. Its primary consumer is **PRST**
+(`patnashev/prst`, a primality-testing utility), which embeds this repo as a `framework/` submodule;
+other Atnashev-family tools consume it the same way. For deeper dives into each subsystem see the
+per-subsystem docs in this folder; the application that drives them is documented in the prst repo's
+`docs/` (start from its `lay-of-the-land.md`).
+
+## What this library is
+
+A C++ framework for **working with very large numbers** and the machinery around long-running
+computations on them. It splits into roughly three layers:
+
+- **Arithmetic substrate** (`arithmetic/`) — `Giant` (a heap bignum, ABI-compatible with gwnum's C
+  `giant`) with `Giants`/`GMP`/`GW` backends; `GWArithmetic`/`GWNum`/`GWState` (FFT-based modular
+  arithmetic over George Woltman's GWnum); number-theory helpers in `integer.*` (gcd, inv, is_prime,
+  phi, jacobi, kronecker, a prime sieve); and specialized arithmetics — `lucas.*`, `edwards.*`,
+  `montgomery.*`, `poly.*`, `group.*`.
+- **Task & I/O layer** (repo root) — the `Task`/`InputTask` base classes (restart, checkpoint cadence,
+  abort handling) that every long computation subclasses; `Logging`/`SubLogging`/`Progress` for results,
+  progress, and time accounting; `File` for fingerprinted checkpoint storage; `FileContainer` for the
+  `.pack` bundle format; `md5` hashing.
+- **Front-end helper** — the `Config` option-parser DSL that consumers use to turn `argv`/`.ini` into
+  their own options structs.
+
+The library owns no `main()`; it is always driven by a consumer.
+
+## Repo layout
+
+```
+arithmetic/                          ← repository root (patnashev/arithmetic)
+├── README.md
+├── docs/                            ← this folder (framework docs + mult_*.pdf references)
+├── arithmetic/                      ← the arithmetic substrate
+│   ├── giant.cpp / giant.h          ← Giant bignum + Giants/GMP/GW backends
+│   ├── arithmetic.cpp / .h          ← GWState, GWArithmetic, GWNum, SerializedGWNum
+│   ├── integer.cpp / .h             ← number theory (gcd/inv/is_prime/phi/jacobi/…), prime sieve
+│   ├── lucas.cpp / .h               ← Lucas-sequence arithmetic (V/U recurrences)
+│   ├── edwards.cpp / .h             ← Edwards-curve arithmetic (ECM; dormant in PRST)
+│   ├── montgomery.cpp / .h          ← Montgomery-curve arithmetic (ECM; dormant in PRST)
+│   ├── poly.cpp / .h                ← polynomial multiplication (dormant in PRST)
+│   ├── group.cpp / .h               ← curve/poly group-formula implementations (large)
+│   ├── field.h / exception.h        ← field abstraction; exception types
+│   └── test.cpp                     ← standalone arithmetic smoke test (own main())
+├── inputnum.cpp / .h                ← number parser + form classification (KBNC/FACTORIAL/…)
+├── logging.cpp / .h                 ← Logging / SubLogging / Progress
+├── task.cpp / .h                    ← Task / InputTask base classes
+├── file.cpp / .h                    ← File checkpoint abstraction (+ FilePacked bridge)
+├── config.cpp / .h                  ← option-parser DSL
+├── container.cpp / .h               ← FileContainer (.pack proof bundles)
+├── md5.c / md5.h                    ← hashing
+├── gwnum/                           ← prebuilt GWnum (Woltman's FFT-based bignum; third-party)
+├── gmp/                             ← prebuilt GMP for Windows (third-party)
+└── bow/                             ← Big Object Writer (BOINC-only state-serialization glue)
+```
+
+Mental model: **this library is "the shared bignum + arithmetic + checkpointing primitives every
+computation reuses"; the consumer (e.g. PRST) decides "what computation do we run and how do we
+orchestrate it?"** Because the surface here is shared across tools, it is a higher-cost change surface
+than a consumer's own code — read the relevant deep-dive before extending an interface.
+
+## The pieces, and where to read more
+
+- **`Giant` / `GWState` / `GWArithmetic`** — the bignum heap model and the FFT math runtime
+  (instruction set, FFT config, modulus, fingerprint, `known_factors` reduction), plus `SerializedGWNum`
+  (the checkpoint bridge) and `ReliableGWArithmetic` round-off escalation. See `arithmetic-foundation.md`.
+- **Curves & polynomials** — the full (`GroupArithmetic`, NAF) vs. differential
+  (`DifferentialGroupArithmetic`, DAC ladder) split; the five concrete arithmetics; chain construction.
+  Only `LucasV`/`LucasUV` is a live PRST consumer; the Edwards/Montgomery ECM and `PolyMult` paths are
+  dormant in PRST. See `curves-and-polynomials.md`.
+- **`Task` / `InputTask`** — the restart loop in `run()`, the checkpoint/progress cadence in
+  `on_state()`, the error-correction handshake, and the `TaskState` base. Every long computation
+  subclasses these. See `task-lifecycle.md`.
+- **`Logging` / `SubLogging` / `Progress`** — results/factor/log files, the progress checkpoint, the
+  parent walk in `update()`, and the staged time accounting (`_time_total`/`_time_stage`). A subtle hot
+  zone. See `logging-and-progress.md`.
+- **`InputNum`** — parse + form classification (`KBNC`/`FACTORIAL`/`PRIMORIAL`/`GENERIC`), the
+  cofactor-divisor form, algebraic factoring, `mod`/fingerprinting, `is_half_factored`. See
+  `inputnum-parsing.md`.
+- **`Writer` / `Reader` / `File` serialization** — the on-disk format (magic + appid + `TYPE` + version
+  + fingerprint header), atomic write + `.md5` sidecar, `unique_fingerprint`, and the appid scheme that
+  lets consumers share the format. See `state-serialization.md`.
+- **`Config` DSL** — the runtime `ConfigObject` tree vs. the CRTP `*Setup` builder; `delim` matching;
+  the builder verbs; the `parse_args` walk and `.ini` parsing. See `config-dsl.md`.
+- **`FileContainer` / `.pack`** — the bundle format (JSON-framed chunks, stream index, codecs, MD5
+  recovery) and the `FilePacked` File-layer bridge. See `container-format.md`.
+
+## Build
+
+This library is consumed as a submodule and built into the consumer's binary; it has no standalone build
+target beyond `arithmetic/test.cpp` (compiled and run by hand for smoke-testing). GWnum and GMP ship as
+prebuilt static libraries under `gwnum/{linux64,mac64,win64}` and `gmp/win64`; a consumer that needs a
+newer GWnum bumps the submodule pointer. Per-platform build wiring (solutions/makefiles) lives with the
+consumer, not here.
+
+## Companion deep-dives in this folder (framework subsystems)
+
+- **`task-lifecycle.md`** — `TaskState` / `Task` / `InputTask`, the restart loop in `run()`, the cadence in `on_state()`, error-correction handshake, concrete subclass tour, pitfalls.
+- **`logging-and-progress.md`** — `Logging` / `SubLogging` / `Progress`, the parent walk in `update()`, persistence, common patterns, pitfalls.
+- **`inputnum-parsing.md`** — `InputNum::parse` classification; the `(<num>)/F` cofactor-divisor form; `Phi`/`Quad`/`Hex` and auto-detected algebraic factoring; the negative-`Giant` factorial/primorial encoding; `mod`/fingerprinting; `is_half_factored`.
+- **`state-serialization.md`** — the `Writer`/`Reader`/`File` on-disk format; the `TYPE` registry and their `TaskState` owners; `Giant`/`SerializedGWNum` encoding; atomic write + `.md5` sidecar; `unique_fingerprint`; the appid compatibility munging.
+- **`arithmetic-foundation.md`** — the bignum substrate: the `Giant` heap model and its `Giants`/`GMP`/`GW` backends; `GWState::setup`; `GWArithmetic`/`GWNum`; `SerializedGWNum`; the `ReliableGWArithmetic` round-off escalation; and the `integer.*` number-theory helpers + prime sieve.
+- **`curves-and-polynomials.md`** — the specialized arithmetic beside the bignum layer: full vs. differential group split; the five concrete arithmetics; `get_NAF_W`/`precomputed_DAC_S_d` chain construction; the liveness map of which paths a consumer (PRST) actually uses.
+- **`config-dsl.md`** — the `Config` option-parser DSL: the runtime `ConfigObject` tree vs. the CRTP `*Setup` builder; the `delim` matching convention; the builder verbs; the `parse_args` walk + group fixpoint + exclusive first-match; `.ini` parsing.
+- **`container-format.md`** — the `.pack` bundle format: the newline-delimited-JSON-record on-disk layout; `Packer`/`FileContainer`/`FilePacked`; codecs, MD5, and the `container_error` recovery codes.
+
+### Consumer (application) deep-dives — in the `patnashev/prst` repo (`docs/`)
+
+How PRST drives this library is documented with the application: `run-hierarchy.md`, `proof-system.md`,
+`abc-batch.md`, `boinc-and-net.md`, `test-harness.md`, `exponentiation-algorithms.md`,
+`math-and-theorems.md`. Start from that repo's `lay-of-the-land.md`.
+
+## Coverage status
+
+Every in-scope framework subsystem has a deep-dive (the eight above). Intentionally scoped out: the
+prebuilt third-party libraries (`gwnum/` — Woltman's FFT bignum — and `gmp/`), understood only at their
+interface; `bow/bow.cpp`, which is BOINC-only build glue relevant only under a consumer's `BOINC` build;
+and the fenced low-level details (`group.cpp`'s curve/poly formulas and `container.cpp`'s writer
+byte-framing), whose docs cover the interface and on-disk layout and point to the code for the rest.
+
+A caution for maintainers: these docs embed verified line numbers and "this is the only live caller"
+claims that reflect the code at the time of writing — re-grep before trusting any such claim. Some claims
+about *who consumes* a given primitive depend on the consumer; citations into `prst/src/...` files point
+at the consumer's code in the `patnashev/prst` repo, not this one.

--- a/docs/logging-and-progress.md
+++ b/docs/logging-and-progress.md
@@ -1,0 +1,305 @@
+# Logging & Progress — deep dive
+
+One of the subtlest subsystems in the codebase. This doc is the reference: what each field means, what each method does, the invariants you must preserve, and the patterns/pitfalls that come from misreading them.
+
+Source files:
+- `logging.h`
+- `logging.cpp`
+- `task.cpp` (only the call sites that drive Progress)
+
+## 1. The three classes at a glance
+
+```
+Progress      ← pure data + arithmetic; no I/O. Owns staged costs and time bookkeeping.
+Logging       ← owns one Progress + result/factor/log files + the progress checkpoint file.
+SubLogging    ← inner-scope Logging that forwards most calls to a parent Logging.
+```
+
+Each `Logging` has exactly one `Progress` (`Logging::_progress`). `SubLogging` is a `Logging` whose `_progress._parent` is set to the parent `Logging`'s `Progress`. There is no shared global state; the only coupling between sub and parent is the parent pointer chain inside `Progress`.
+
+## 2. Progress: fields and what they mean
+
+```cpp
+class Progress {
+    std::vector<double> _costs;     // per-stage expected work (registered via add_stage)
+    double _total_cost = 0;         // sum of _costs
+    int    _cur_stage = 0;          // index into _costs
+    double _cur_progress = 0;       // 0..1, fractional progress through _costs[_cur_stage]
+    double _time_total = 0;         // DURABLE elapsed seconds; only update()/time_init() change it
+    double _time_stage = 0;         // TRANSIENT; reset to 0 by every update() on this Progress
+    double _time_op = 0;            // most recent estimated seconds-per-operation
+    double _timer = 0;              // last getHighResTimer() reading; 0 ⇒ uninitialized
+    int    _op_count = 0;           // most recent ops() snapshot
+    Progress* _parent = nullptr;    // set by set_parent(); SubLogging wires this in its ctor
+    std::map<std::string, std::string> _params;   // name=value pairs persisted to .param file
+};
+```
+
+**The two time fields are the trap.** They serve different roles:
+
+| Field         | Lifecycle                                                                  | Who increments it                                                                     |
+|---------------|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `_time_total` | Persists across `update()` calls and across runs (saved to `.param`).      | `update()` on **this** Progress; `time_init()` on resume; nothing else.               |
+| `_time_stage` | Transient — wiped to 0 by every `update()` on **this** Progress.           | `update()` on a **descendant** Progress (the parent walk adds elapsed up the chain).  |
+
+`time_total()` returns `_time_total + _time_stage`, so a *correct* report at any moment is the sum of "what's been credited durably" + "what descendants have added since this Progress's own last update."
+
+## 3. Progress: the methods
+
+```cpp
+void reset();                                  // zero all bookkeeping
+void add_stage(double cost);                   // append to _costs, increase _total_cost
+void next_stage();                             // _cur_stage++; then update(0, 0)
+void skip_stage();                             // _cur_stage++ only — does NOT call update()
+void update(double progress, int op_count);    // see §4
+void time_init(double elapsed);                // _time_total = elapsed; _timer = now
+void set_parent(Progress* parent);             // wires _parent for the update() walk; SubLogging ctor uses it
+
+double progress_stage();                       // _cur_progress
+double progress_total();                       // weighted progress across all stages, 0..1
+double cost_total();                           // _total_cost
+double time_total();                           // _time_total + _time_stage   ← composed
+double time_op();                              // _time_op
+int    op_count();                             // _op_count (last snapshot passed to update())
+int    num_stages();                           // _costs.size()
+int    cur_stage();                            // _cur_stage
+
+std::string& param(const std::string& name);   // mutable; auto-creates
+int    param_int(const std::string& name);     // strtol of the string param ("" → 0)
+double param_double(const std::string& name);  // strtod of the string param ("" → 0.0)
+std::map<std::string, std::string>& params();  // raw map; used by progress_save / file_progress
+```
+
+The correct approach is to call `update()` on the outer Progress with `(progress_stage(), 0)`; that captures wall-clock into `_time_total` via the existing `_timer` anchor. See §6 and §10.
+
+## 4. `update()` — the heart of the mechanism
+
+This is the only function you really need to internalize. From `logging.cpp:10-31`:
+
+```cpp
+void Progress::update(double progress, int op_count) {
+    _cur_progress = progress;
+    if (_timer == 0)
+        _timer = getHighResTimer();
+    double elapsed = (getHighResTimer() - _timer) / getHighResTimerFrequency();
+    _timer = getHighResTimer();
+    _time_total += elapsed;        // 1. credit wall-clock since last update on THIS progress
+    _time_stage = 0;               // 2. wipe transient field
+    if (_op_count < op_count)
+        _time_op = elapsed / (op_count - _op_count);
+    _op_count = op_count;
+
+    Progress* cur = this;
+    Progress* parent = _parent;
+    while (parent != nullptr) {    // 3. walk UP, poking each ancestor
+        parent->_cur_progress = cur->progress_total();
+        parent->_time_stage  += elapsed;
+        cur = parent;
+        parent = cur->_parent;
+    }
+}
+```
+
+What this does, in three steps:
+
+1. **Credit elapsed time durably on this Progress.** `_time_total += (now − _timer)`. `_timer` is the wall-clock anchor; once initialized it's monotonic.
+2. **Reset `_time_stage` on this Progress to 0.** Important: the design rationale is that `_time_stage` is "what descendants have added since *my* last update." Once *I* have updated, that contribution has been observed, and starts over.
+3. **Walk the parent chain** updating each ancestor: their `_cur_progress` is set to this descendant's overall progress, and the same `elapsed` is added to each ancestor's `_time_stage`. (Note: NOT to `_time_total`. That's deliberate — only an ancestor's own `update()` can credit `_time_total`.)
+
+Implications worth pinning:
+
+- **Calling `update()` on a SubLogging's Progress ≠ calling `update()` on the parent.** The sub's update increments parent's `_time_stage` only. The parent's `_time_total` is not touched until *the parent's own* `update()` fires.
+- **The first call ever to `update()` returns `elapsed = 0`** (because `_timer == 0` initially gets initialized to `now`). This is why `Logging::file_progress()` calls `time_init()` at startup — it pre-arms `_timer` so the first real `update()` is meaningful.
+- **`_time_stage` is not additive across siblings.** If two children both call `update()`, the parent's `_time_stage` gets `elapsed_1 + elapsed_2`. But the next call to the parent's own `update()` will reset it to 0, capturing the cumulative wall-clock into `_time_total` instead.
+
+## 5. Logging: fields and methods
+
+```cpp
+class Logging {
+    int     _level;                      // gate for debug/info/warning/error/result
+    Progress _progress;                  // the single owned Progress; exposed via progress()
+    File*   _file_progress = nullptr;    // .param checkpoint
+    std::string _file_result = "result.txt";       // result lines persisted here via result_save()
+    std::string _file_factor = "factors.txt";      // factors emitted by report_factor() appended here
+    std::string _file_log;               // optional log file
+    std::string _prefix;                 // printed before every report() line
+    bool    _print_prefix = true;        // controls whether _prefix is printed next; toggled by report() based on prior message
+    bool    _overwrite_line = false;     // for `\r`-style progress overwrite
+};
+```
+
+Levels (sorted ascending):
+
+```
+LEVEL_DEBUG   = 0
+LEVEL_INFO    = 1
+LEVEL_PROGRESS= 2     ← report_progress() emits at this level (overwriting line)
+LEVEL_WARNING = 3
+LEVEL_ERROR   = 4
+LEVEL_RESULT  = 5     ← result() emits at this level
+```
+
+`report()` is the single output funnel. `info/warning/error/debug/result` all build a buffer with `vsnprintf`, gate against `_level`, and call `report()`. Two side effects in `report()`:
+- Optional progress-line overwrite: if the previous output was a progress line (`_overwrite_line == true`), prefix the new line with a CR + spaces to overwrite it.
+- Optional log-file mirror: if `_file_log` is set and the level is not `LEVEL_PROGRESS`, append to that file.
+
+`warning()` and `error()` auto-persist: each calls `result_save(buf)` immediately after `report()` (`logging.cpp:72-73` and `logging.cpp:85-86`). `result()` does **not** auto-persist — its body (`logging.cpp:89-99`) only calls `report()`. Result lines land in `_file_result` only because callers invoke `logging.result_save(...)` separately, often with a slightly different string (as the §11 table shows, and as at `prst/src/fermat.cpp:420-421`, where `result()` prints `time_total()` as a float and the following `result_save()` writes the integer-second form).
+
+`report_progress()` formats one of the two human-readable progress strings (with or without "stage / total" depending on `num_stages() > 1`) and emits at `LEVEL_PROGRESS`. It is called from `Task::on_state()` every `Task::PROGRESS_TIME` seconds (default 10).
+
+`progress_save()` writes `_progress._params` (including the `time_total` parameter) to the `.param` file. `Task::on_state()` triggers this every `Task::DISK_WRITE_TIME` seconds (default 300) and also on abort. Empty values are skipped.
+
+`file_progress()` reads the `.param` file at startup, repopulates `_params`, and calls `_progress.time_init(_params["time_total"])`. This is how time accounting survives restarts.
+
+## 6. SubLogging: what it overrides
+
+```cpp
+class SubLogging : public Logging {
+    SubLogging(Logging& parent, int level = LEVEL_WARNING)
+        : Logging(level), _parent(parent) {
+        progress().set_parent(&parent.progress());     // <-- the parent walk hookup
+    }
+
+    // forward-to-parent overrides:
+    report(message, level)            → _parent.report(prefix+message, level)   // (prefix added once)
+    report_param(name, value)         → super; then _parent.report_param(name, value)   // store on sub's progress AND mirror to parent's progress, so both are queryable
+    report_factor(input, f)           → _parent.report_factor(input, f)         // factors are global; only the parent owns the factors.txt file
+    progress_save()                   → super; then _parent.progress_save()     // sub's _file_progress is usually null (no-op); parent does the real .param write
+    heartbeat()                       → _parent.heartbeat()                     // BOINC heartbeat is process-wide, only the outer Logging is wired to it
+};
+```
+
+Things to keep straight:
+
+- **The constructor wires the parent, but the generic production users detach it.** The `SubLogging` ctor does call `set_parent(&parent.progress())` (`logging.h:111`), so a SubLogging *left attached* (e.g. the test harness at `prst/src/testing.cpp:269`) walks up to its parent. But both generic production users immediately sever the link: `MorrisonGeneric` and `PocklingtonGeneric` call `_logging->progress().set_parent(nullptr)` right after constructing the SubLogging (`prst/src/morrison.cpp:456`, `prst/src/pocklington.cpp:250`), and then re-null per inner node via `_logging->progress() = Progress();` (`prst/src/morrison.cpp:684`, `prst/src/pocklington.cpp:464`; a default `Progress` has `_parent == nullptr`, `logging.h:46`). So the observation "parent set to nullptr" is a **correct** factual reading of those call sites — but it does not explain lost time: the cause is the wiped `_time_stage`, not the null parent. The fix lives elsewhere; see §9. (Sibling docs `run-hierarchy.md` (in the patnashev/prst repo) and `lay-of-the-land.md` (in the patnashev/prst repo) describe it this way.)
+- **A SubLogging has its own Progress** with its own `_costs`, `_time_total`, etc. *If still attached*, its `update()` updates its own fields *and* walks up to the parent. In `MorrisonGeneric`/`PocklingtonGeneric` the parent is detached, so the sub's `update()` touches only the sub's own fields. Either way, reading a SubLogging's `time_total()` gives the sub's own elapsed; reading the parent's `time_total()` gives whatever the parent has credited durably plus what descendants (if any are attached) have added in the current `_time_stage` window.
+- **`progress_save()` cascades.** When the inner code does `_logging->progress_save()`, both the inner SubLogging's `_file_progress` (often null — sub doesn't usually own one) and the parent's persistent `.param` file get written.
+- **Default sub level is `LEVEL_WARNING`.** Inner-task chatter is suppressed unless the caller bumps the level. Result lines from the sub still bubble up through `report()`.
+- **Prefix applies to forwarded messages.** `_parent.report(prefix+message, level)`. The sub adds its prefix, the parent prints it. Don't set the same prefix on both or you'll get it doubled.
+
+## 7. The driver: how `Task` exercises Progress
+
+`Task::on_state()` (`task.cpp:163`) is the periodic callback inside any long-running task. It calls `_logging->progress().update(progress(), ops())` under three conditions:
+
+1. **Disk-save tick** (every `DISK_WRITE_TIME` seconds, default 300, or on abort):
+   `update(progress, ops)` → `state_save()` → `write_state()` → `update(progress, ops)` again → `progress_save()`.
+2. **Progress tick** (every `PROGRESS_TIME` seconds, default 10):
+   `update(progress, ops)` → `report_progress()`.
+3. **Always at the end:** `_logging->heartbeat()` (BOINC uses this).
+
+`InputTask::init()` calls `update(0, ops())` at the start; `InputTask::done()` calls `update(1, ops())` at the end. Together these bracket the task's lifetime so — **when the Progress still has a parent attached** — the parent walk gets a clean elapsed=0 baseline at start and a final settle at the end.
+
+Net: every long task automatically drives `update()` on its own Logging's Progress. If that Logging is a SubLogging **whose parent is still attached** (e.g. the `-test` harness, `prst/src/testing.cpp:269`), every drive-by also walks up to the outer's `_time_stage`. **But the two generic production users detach it:** `MorrisonGeneric`/`PocklingtonGeneric` call `set_parent(nullptr)` right after constructing the SubLogging (`prst/src/morrison.cpp:456`, `prst/src/pocklington.cpp:250`) and re-null the sub's Progress per inner node, so there the drive-by touches only the sub's own fields and never walks up — the outer's durable time is credited by an explicit `update()` on the *outer* Progress instead (see §6 and §9). **For the attached case you don't need to push time anywhere yourself** — the existing wiring already does it. What you do need is for the outer's own `update()` to fire periodically too, so `_time_total` accumulates durably and isn't all riding on the doomed `_time_stage`.
+
+## 8. The persistence model
+
+The only thing persisted across runs is the `.param` text file. Format: lines of `key=value`. The key `time_total` is special — `file_progress()` feeds it to `time_init()` so wall-clock continues from where it left off.
+
+```
+time_total=143.872
+P=5
+next_fft=1
+...
+```
+
+`progress_save()` writes empty-skipping. So a value of `""` is removed on next save; a value of `"0"` is kept. To clear a param, set it to `""`.
+
+There is no on-disk schema for `_costs` or `_cur_stage`. **Stages are reconstructed in code on each run.** A test class's constructor (or `run()` setup phase) re-builds the same `add_stage(...)` calls deterministically so progress percentages match across resumes. If you rearrange or add stages, percentages from the old `.param` will look wrong until the run completes.
+
+`time_init()` re-anchors `_timer` to "now" and sets `_time_total` to the saved elapsed. `_time_stage` is implicitly zero on a fresh load.
+
+## 9. Common patterns in this codebase
+
+### Outer test class with no sub-tasks (e.g. `Fermat::run`)
+
+```
+ctor:                progress.add_stage(task->cost());    // register expected work
+run() body:          task->run();                         // Task::on_state drives update() on logging.progress()
+result print:        time_total() returns the real elapsed time durably accumulated in _time_total.
+```
+
+No extra Progress glue needed. Time accounting just works.
+
+### Outer test that hands inner tasks a SubLogging (e.g. `MorrisonGeneric`, `PocklingtonGeneric`)
+
+```
+ctor:
+    _logging = make SubLogging(parent_logging)            ← ctor wires the parent walk...
+    _logging->progress().set_parent(nullptr)              ← ...but it is detached right away
+    register outer-level stages on parent_logging.progress() (one per inner factor, etc.)
+
+run() body, per iteration:
+    _logging->progress() = Progress()              ← fresh sub Progress (re-nulls _parent)
+    _logging->progress().add_stage(cur_task->cost())
+    cur_task->init(..., _logging.get(), ...)       ← inner uses the SubLogging
+    cur_task->run()                                ← drives _logging->progress().update()
+                                                     on the DETACHED sub; touches only the
+                                                     sub's own fields, does NOT walk up
+    _logging->progress().next_stage()
+    logging.progress().update(progress_stage, 0)   ← THIS LINE, a direct call on the OUTER
+                                                     Progress, captures the inner-task elapsed
+                                                     time durably into outer._time_total and
+                                                     resets outer._time_stage to 0.
+    cur_task.reset()
+```
+
+That trailing `update()` on the *outer* Progress (`prst/src/morrison.cpp:732`, `prst/src/pocklington.cpp:503`) is the upstream fix from `d14b2f7`. Because the sub's Progress is detached, the inner task never adds elapsed time to the outer's `_time_stage`; the outer's durable time is credited solely by this explicit direct call right after the inner task. (Note the *other* outer-side `update()` — the per-iteration heartbeat at `prst/src/morrison.cpp:490` — only wipes `_time_stage` to 0; if the d14b2f7 line were absent, the inner-task time would simply never be credited at all.)
+
+### Resuming from a checkpoint
+
+`prst/src/prst.cpp:332` opens the `.param` file, `logging.file_progress(&file_progress)` loads it. `time_init()` sets `_timer` and `_time_total`. From there everything proceeds as a fresh run, except the result line will report the cumulative elapsed time across all sessions.
+
+## 10. Pitfalls — and how to avoid them
+
+### Pitfall A: assuming `_time_stage` persists past the next `update()`
+
+It doesn't. If you measure, store, or compare `_time_stage` across multiple `update()` calls on the same Progress, you have a bug. Anything that needs to persist must land in `_time_total`.
+
+### Pitfall B: thinking the parent walk credits `_time_total`
+
+It only writes to ancestors' `_time_stage`. Their `_time_total` is updated only when *they themselves* call `update()`. If an outer Progress never gets its own `update()`, its `_time_total` stays at whatever `time_init()` set.
+
+### Pitfall C: extending the API instead of using `update()`
+
+A tempting mistake is to add `Progress::add_time(double)` so the caller could push `task->timer()` into `_time_total` directly. But the existing `update()` already captures wall-clock into `_time_total` via the `_timer` anchor. The minimal fix is one outer `update()` call after the inner task — no new API.
+
+Heuristic: **if you're proposing a new method on `Progress`, re-read the existing six methods first.** If your proposal is functionally a recombination of `update()` + `set_parent()` + `add_stage()`, you don't need a new method.
+
+### Pitfall D: calling `update()` on a SubLogging when you meant the parent
+
+Easy to do because the syntax is the same. `_logging->progress().update(...)` only walks UP from the sub; it doesn't write to the parent's `_time_total`. If you want the parent to credit elapsed time durably, call `logging.progress().update(...)` (the outer one) — that's an entirely different code path.
+
+### Pitfall E: re-ordering `add_stage` calls between runs
+
+`.param` doesn't store stage layout. The code is the schema. Add new stages at the end of an existing layout, and ideally only when you need them — re-ordering changes the meaning of `progress_total()` for in-flight checkpoints.
+
+### Pitfall F: setting an empty param to clear it
+
+`progress_save()` skips empties. If you want to clear a param, set its value to `""` and `progress_save()`. Setting it to `"0"` keeps it.
+
+### Pitfall G: relying on `time_op()` for short tasks
+
+`_time_op` is only updated when `op_count` strictly increases. Tasks that pass `op_count = 0` to `update()` (which most outer test-level updates do) leave `_time_op` stale. Don't read `time_op()` from outside `Task::on_state()`-driven code paths.
+
+## 11. Quick reference — when to call what
+
+| You want to…                                                  | Call                                                                            |
+|---------------------------------------------------------------|---------------------------------------------------------------------------------|
+| Register expected work for a new stage                        | `progress().add_stage(cost)`                                                    |
+| Move to the next stage and tick the parent                    | `progress().next_stage()`                                                       |
+| Move to the next stage WITHOUT pinging parents                | `progress().skip_stage()`                                                       |
+| Periodic heartbeat from inside a long task                    | `_logging->progress().update(progress(), ops())` (already done by Task)         |
+| Capture inner-task elapsed time durably to the outer's total  | `logging.progress().update(logging.progress().progress_stage(), 0)`             |
+| Persist progress to disk                                      | `logging.progress_save()`                                                       |
+| Reload progress on startup                                    | `logging.file_progress(&file_progress)`                                         |
+| Re-anchor wall-clock after manual time mutation               | `progress().time_init(progress().time_total())`                                 |
+| Emit a user-facing result line                                | `logging.result(success, "...")` + `logging.result_save("...")`                 |
+| Emit a one-shot info line                                     | `logging.info("...")`                                                           |
+| Emit an overwriting progress line                             | `logging.report_progress()` (auto-formatted) or `report(buf, LEVEL_PROGRESS)`   |
+
+## 12. Open questions / things this doc punts on
+
+- **`heartbeat()` semantics.** Base class is a no-op; BOINC override does real work. Worth its own short doc once the BOINC path is in play.
+- **`state_save_flag` / `state_save`.** Used by Task::on_state to coordinate disk writes. Driven by BOINC and net.cpp paths; a future doc on those paths should cover it.
+- **Thread-safety.** None of `Logging`, `SubLogging`, or `Progress` is documented as MT-safe, and that's fine under the current architecture. PRST does use multiple threads — `-t <threads>` and `-spin <threads>` are user-facing — but the parallelism lives *inside* GWnum, parallelizing a single bignum multiplication. Above the GWnum layer, exactly one `Task` runs at a time on the main thread, and Logging/Progress are only mutated from that thread. The two known exceptions are benign: `Task::abort()` from the SIGTERM handler only flips a `bool _abort_flag`, and BOINC's heartbeat similarly only nudges a flag. If multi-`Task` parallelism is ever added above GWnum (e.g. parallel inner factors in `MorrisonGeneric`), this whole subsystem needs locking — `update()`'s parent walk in particular is racy by construction.
+- **Why `_time_stage` exists at all.** It looks like a vestigial design from a moment when ancestor reporting needed to know "time since I was last asked." A simpler model would be "every Progress's `_time_total` is sole truth; ancestors aggregate on read," but changing that would break the existing reporting semantics.

--- a/docs/state-serialization.md
+++ b/docs/state-serialization.md
@@ -1,0 +1,201 @@
+# State serialization — deep dive
+
+Every checkpoint, recovery point, proof point, certificate, and progress file PRST writes goes through one small layer: `Writer`/`Reader`/`File` in `file.{h,cpp}`. A test's `TaskState` subclass describes *what* to serialize (its fields); `File` wraps that in a fixed binary header, hashes it, and writes it atomically. This is the **on-disk contract**: any change to the header layout, the `TYPE` discriminators, or a `TaskState`'s field order breaks resumability for in-flight work and for files written by older builds.
+
+Three facts to anchor on before reading the code:
+
+1. **Files are typed and fingerprinted.** Every file starts with a magic number, an `appid`, a one-byte `TYPE`, a version byte, and (usually) a 32-bit fingerprint. `File::read(TaskState&)` refuses to load a buffer whose `TYPE` doesn't match the state being read into — so a `.ckpt` from one test class can't be misread as another's.
+2. **`TYPE` is a global, hand-assigned namespace.** The values `{1,2,3,4,6,8,9,10,11}` are spread across `prst/src/exp.h`/`prst/src/lucasmul.h`/`prst/src/proof.h` as `static const` constants (5 and 7 are unused/retired). Reusing or renumbering one silently aliases two on-disk formats.
+3. **Writes are crash-safe; reads are hash-checked.** `File::commit_writer` writes to `<name>.new` (on Windows via `FILE_FLAG_WRITE_THROUGH` so the data is flushed to disk; on POSIX via plain `fopen`+`fwrite`+`fclose` with **no** `fsync`, so durability isn't guaranteed before the rename), then removes the old file and renames `.new` over the original, and drops a `<name>.md5` sidecar. `read_buffer` verifies that sidecar and discards a corrupt buffer (treated as "no checkpoint" → restart from scratch).
+
+Source files:
+- `file.h`, `file.cpp` (`Writer`, `Reader`, `TextReader`, `File` + `FileEmpty`/`FilePacked`)
+- `md5.{h,c}` (the MD5 used for the sidecar and `unique_fingerprint`)
+- `prst/src/support.{h,cpp}` (`LLR2File`, the LLR2-compatibility variant)
+- The `TaskState` subclasses that own the `TYPE` constants: `prst/src/exp.h` (1, 2, 8), `prst/src/lucasmul.h` (9, 10, 11), `prst/src/proof.h` (3, 4, 6)
+- `task.{h,cpp}` (`TaskState` base — the per-record `iteration` prefix)
+
+Prereqs / companions: `task-lifecycle.md` (`TaskState`/`Task`; the `on_state` cadence that decides *when* a checkpoint is written), `proof-system.md` (in the patnashev/prst repo) (the `Proof::State`/`Product`/`Certificate` records, TYPEs 3/4/6, and the `.pack` `FilePacked` container), `boinc-and-net.md` (in the patnashev/prst repo) (`NetFile`/`LLR2NetFile` ship these exact buffers over HTTP).
+
+## 1. The on-disk layout
+
+Every file `File::write` produces has this shape:
+
+```
+offset  size  field
+  0      4    MAGIC_NUM = 0x9f2b3cd4          (uint32, little-endian)
+  4      1    appid                            (PRST = 4; default 1; LLR2 = 2)
+  5      1    format_version                   (always 0 today — the "(0 << 8)")
+  6      1    TYPE                             (the TaskState discriminator)
+  7      1    version                          (TaskState::version(), always 0 today)
+  8      4    fingerprint                      (uint32 — present only if fingerprint != 0)
+ 8/12   ...   body                             (the TaskState record)
+```
+
+Bytes 4–7 are a single `uint32` packed as `appid | (format_version << 8) | (type << 16) | (version << 24)` (`file.cpp:205`). The fingerprint word is conditional: a file constructed with fingerprint `0` (e.g. progress `.param` files) omits it and the body starts at offset 8; otherwise the body starts at offset 12.
+
+The **body** is whatever the `TaskState` subclass writes, and it always begins with the base class's 4-byte `iteration` (`task.cpp:21-24`), followed by the subclass's own fields in declaration order.
+
+A separate **`<filename>.md5`** sidecar holds the 32-char hex MD5 of the file body (when `File::hash` is true, the default).
+
+## 2. The write/read round trip
+
+**Writing** (`file.cpp:355-369`, header at `:201-209`):
+
+```cpp
+Writer* File::get_writer(char type, char version)
+{
+    Writer* writer = get_writer();                  // reuses the file's buffer, cleared
+    writer->write(MAGIC_NUM);
+    writer->write(appid + (0 << 8) + ((unsigned char)type << 16) + ((unsigned char)version << 24));
+    if (_fingerprint != 0)
+        writer->write(_fingerprint);
+    return writer;
+}
+
+bool File::write(TaskState& state)
+{
+    try {
+        std::unique_ptr<Writer> writer(get_writer(state.type(), state.version()));
+        state.write(*writer);                        // body: iteration + subclass fields
+        commit_writer(*writer);                      // atomic .new → rename, + .md5 sidecar
+    } catch (const std::exception&) { return false; }
+    state.set_written();
+    return true;
+}
+```
+
+**Reading** (`file.cpp:259-275, 342-353`):
+
+```cpp
+Reader* File::get_reader()
+{
+    read_buffer();                                   // load file + verify .md5
+    if (_buffer.size() < 8) return nullptr;
+    if (*(uint32_t*)_buffer.data() != MAGIC_NUM) return nullptr;
+    if (_buffer[4] != appid) return nullptr;                       // appid must match
+    if (_fingerprint != 0 && _buffer.size() < 12) return nullptr;
+    if (_fingerprint != 0 && *(uint32_t*)(_buffer.data() + 8) != _fingerprint) return nullptr;  // fingerprint must match
+    return new Reader(_buffer[5], _buffer[6], _buffer[7], _buffer.data(), (int)_buffer.size(),
+                      _fingerprint != 0 ? 12 : 8);   // pos = start of body
+}
+
+bool File::read(TaskState& state)
+{
+    std::unique_ptr<Reader> reader(get_reader());
+    if (!reader) return false;
+    if (reader->type() != state.type()) return false;   // TYPE must match the target state
+    if (!state.read(*reader)) return false;              // truncation/format error → false
+    state.set_written();
+    return true;
+}
+```
+
+Every gate that fails returns `nullptr`/`false`, which the caller treats as "no usable checkpoint" → the test starts (or restarts) from the beginning. There is no partial recovery: a file that fails magic, appid, fingerprint, TYPE, or a truncated body read is simply ignored. That's the safe default — a stale or foreign file never corrupts a run.
+
+## 3. Field & method reference
+
+**`Writer`** (`file.h:13-40`, `file.cpp:17-80`) — append-only byte buffer:
+
+| Method | Encoding |
+|---|---|
+| `write(T)` (arithmetic) | raw `sizeof(T)` bytes, little-endian (template, `file.h:23-24`) |
+| `write(const std::string&)` | `uint32` length + raw bytes (`file.cpp:22-26`) |
+| `write(const Giant&)` | `int32` length **(negated if value < 0 — the sign carries the Giant's sign)** + `len*4` limb bytes (`file.cpp:28-35`) |
+| `write(const SerializedGWNum&)` | `uint32` word count + `count*4` bytes (`file.cpp:37-41`) |
+| `write_text` / `write_textline` | raw text; `_textline` appends `\r\n` |
+| `hash()` / `hash_str()` | MD5 of the buffer (16 bytes / 32 hex chars) |
+
+**`Reader`** (`file.h:42-65`, `file.cpp:82-157`) — positional reader over the loaded buffer, carrying the parsed `type`/`version`. Each `read` bounds-checks against `_size` and returns `false` on underrun. The `Giant` reader reconstructs sign from the negated length (`:140-141`); the `SerializedGWNum` reader takes word count × 4 bytes.
+
+**`File`** (`file.h:82-126`) — the unit of persistence:
+
+| Member | Role |
+|---|---|
+| `read(TaskState&)` / `write(TaskState&)` | the typed round trip above. |
+| `get_reader` / `get_writer(type,version)` | low-level header framing. |
+| `get_textreader` / `write_text` | unframed text (used by `-batch` files, the `stderr` net log). |
+| `read_buffer` / `commit_writer` / `free_buffer` / `clear` | the I/O verbs (overridden by subclasses). |
+| `add_child(name, fp)` | a dotted-name sub-file (e.g. per-base `.ckpt.<a>`), inheriting `hash`. |
+| `unique_fingerprint(fp, id)` | `static`: `MD5(fp-bytes ‖ id)`, first 4 bytes → `uint32` (`file.cpp:182-192`). |
+| `hash` (bool) | whether to write/verify the `.md5` sidecar (default true). |
+| `appid` (int) | the byte-4 application id; PRST sets `File::FILE_APPID = 4` (`prst/src/prst.cpp:53`). |
+
+**The `File` hierarchy:**
+- `File` — local disk (`read_buffer` = `fopen`+read+verify-md5; `commit_writer` = atomic write).
+- `FileEmpty` (`file.h:128-136`) — a `/dev/null`: reads nothing, writes nothing. Used where a `File&` is required but no persistence is wanted.
+- `FilePacked` (`file.h:143-158`, `file.cpp:385-509`) — backed by a `container::FileContainer` (the proof `.pack`); `get_writer` returns a streaming `FilePackedWriter`. See `proof-system.md`.
+- `LLR2File` (`prst/src/support.{h,cpp}`) — local disk + LLR2 on-disk compatibility munging (§5).
+
+## 4. The TYPE registry & the TaskState record
+
+`File::read` keys off `TYPE`, so the constant is the format's identity. Every `TaskState` subclass that overrides `read`/`write` serializes `iteration (uint32)` then its own fields, in declaration order (TYPE 6 is the lone exception — see notes):
+
+| TYPE | Owner class | File | Body after `iteration` |
+|---|---|---|---|
+| 1 | `BaseExp::StateValue` | `prst/src/exp.h:42` | `Giant` value |
+| 2 | `StrongCheckMultipointExp::StrongCheckState` | `prst/src/exp.h:308` | `int recovery` + `SerializedGWNum X` + `SerializedGWNum D` |
+| 3 | `Proof::Product` | `prst/src/proof.h:26` | `Giant X` (here `iteration` = tree depth) |
+| 4 | `Proof::Certificate` | `prst/src/proof.h:40` | `Giant X` + optional `Giant a_power` + `Giant a_base` |
+| 6 | `Proof::State` | `prst/src/proof.h:59` | **no standard `read`/`write` override** — fields `SerializedGWNum X`, `Giant Y`, `Giant exp`, `vector<Giant> h` are held in memory, not laid out by the generic path (see notes) |
+| 8 | `BaseExp::StateSerialized` | `prst/src/exp.h:29` | `SerializedGWNum` value |
+| 9 | `LucasVMulFast::State` | `prst/src/lucasmul.h:35` | `int index` + `Giant V` + `int parity` |
+| 10 | `LucasUVMul::State` | `prst/src/lucasmul.h:110` | `Giant Vn` + `Giant Vn1` + `int parity` |
+| 11 | `LucasUVMul::StrongCheckState` | `prst/src/lucasmul.h:130` | `int recovery` + `SerializedGWNum Vn` + `Vn1` + `int Vparity` + `U` + `V` + `int parity` |
+
+Notes:
+- **TYPE 6 (`Proof::State`) is the one record without a `read`/`write` override** (`prst/src/proof.h:56-77` — constructors, setters, accessors, fields, but no serialization methods, inline or out-of-line). Through `File::read/write` it would persist only the base `iteration`; its `X`/`Y`/`exp`/`h` payload is managed by the proof code (`ProofSave`/`ProofBuild`), not the generic `TaskState` mechanism described here. Don't assume the standard "iteration + fields" layout applies to it — see `proof-system.md`.
+- **5 and 7 are absent** — either retired or never assigned. Don't backfill them assuming they're free; treat the whole range as a contract and only ever *append*.
+- `version()` is `0` for every state today (`task.h:35`), so byte 7 is always 0. The version byte exists precisely so a future field change can be made readable old-and-new without a TYPE bump — bump `version()` and branch in `read`.
+- `bool`s are written as `int` `1`/`0` (e.g. `parity`, `LucasVMulFast::State::write`, `prst/src/lucasmul.h:45`), not a single byte.
+- `Proof::Certificate::read` is **forward/backward tolerant**: it reads `X`, then *optionally* `a_power`+`a_base` via `((reader.read(_a_power) && _a_power != 0 && reader.read(_a_base)) || true)` (`prst/src/proof.h:48`) — an older 1-field certificate still loads. This is the one record that deliberately tolerates a shorter body; the rest fail closed on truncation.
+
+A checkpoint's lifecycle (see `task-lifecycle.md` for the cadence): `Task` calls `File::write(state)` on the `DISK_WRITE_TIME` interval and at completion; on restart `File::read(state)` repopulates `state` and the test resumes from `state.iteration()`. The recovery point (`.rcpt`) and checkpoint (`.ckpt`) are two such files used in the Gerbicz/strong-check handshake.
+
+## 5. Integrity, atomicity, fingerprints, and LLR2
+
+**Atomic write** (`file.cpp:283-323`): `commit_writer` writes the buffer to `<name>.new` via `writeThrough` (Windows `FILE_FLAG_WRITE_THROUGH`, else `fopen`+`fwrite`), `remove`s the old file, then `rename`s `.new` over it. A crash mid-write leaves an intact original plus a stray `.new`; it never leaves a half-written checkpoint. The `.md5` sidecar is written after.
+
+**MD5 verification** (`file.cpp:234-256`): `read_buffer` loads the file, then — if `hash` and a non-empty `<name>.md5` exists — recomputes the MD5 and **clears the buffer on mismatch**. A corrupt checkpoint is thus indistinguishable from a missing one: the test restarts rather than trusting bad state. `md5.{h,c}` provides `MD5Init/Update/Final` and the `md5_raw_input(out[33], …)` hex helper.
+
+**`unique_fingerprint`** (`file.cpp:182-192`): `MD5(fingerprint-bytes ‖ unique_id)[0:4]` as a `uint32`. This is how per-base / per-point child files get distinct fingerprints (e.g. `Pocklington` opens `.ckpt.<a>` children, the proof system salts by point position) so two sub-runs can't read each other's checkpoints even under the same parent filename.
+
+**`LLR2File`** (`prst/src/support.cpp:13-52`) — bidirectional compatibility with LLR2's on-disk format, so a PRST worker can resume an LLR2 checkpoint and vice-versa. The munging is purely in the header/trailer bytes:
+- **On read** (`:20-31`): if the buffer looks like an LLR2 file (`MAGIC_NUM`, **`_buffer[4] == 2`** — i.e. LLR2's `appid`), rewrite `_buffer[4] = 4` (PRST's appid) and `_buffer[6] = _type` (set the TYPE byte), and for a `StateValue` (TYPE 1) **decrement** the iteration word at offset 12.
+- **On write** (`:33-52`): the inverse — `buffer[4] = 2`, `buffer[6] = 0`, **increment** the `StateValue` iteration at offset 12, then append an LLR2 trailer: a zero `uint32`, a 32-bit additive checksum (sum of `uint32`s from offset 8 to end), and 20 zero `uint32`s.
+
+> Byte 4 is the **appid**, not a format version — LLR2 stamps `2`, PRST stamps `4`. (The companion `boinc-and-net.md` originally described this as a "v2/v4 header"; that's corrected to "appid" there.) The off-by-one on the `StateValue` iteration reflects that LLR2 counts the iteration one differently from PRST.
+
+`LLR2NetFile` in `prst/src/net.cpp` is the same munging over an HTTP-backed `NetFile` (see `boinc-and-net.md` §5).
+
+## 6. Pitfalls
+
+- **`TYPE` is a permanent on-disk contract.** Renumbering or reusing a value silently makes two record formats collide; `File::read`'s type-match (`file.cpp:347`) would accept the wrong body and mis-deserialize. Only ever *append* new TYPEs (and remember 5 and 7 are holes, not free slots). Bumping a TYPE without a backward-compat read path orphans every in-flight checkpoint.
+- **Field order is the format.** `Writer`/`Reader` are positional with no field tags. Inserting a field in the middle of a `TaskState::write`, or reordering, breaks every existing checkpoint for that TYPE. Append at the end and gate on `version()` if you must extend.
+- **`Reader::read(double)` under-checks bounds.** It verifies only 4 bytes remain but reads and advances 8 (`file.cpp:109-116`) — a latent over-read if a double sits in the last 4–7 bytes. No current `TaskState` serializes a `double`, so it's dormant, but don't add one without fixing the check.
+- **appid is part of the identity.** A file written with the default `appid 1` or by LLR2 (`2`) won't load under PRST (`appid 4`) without the `LLR2File` path — `get_reader` rejects on `_buffer[4] != appid` (`file.cpp:267`). If checkpoints "aren't resuming" across tools, check the appid byte first.
+- **`hash = false` files skip integrity *and* the sidecar.** Progress `.param` files set `hash = false` (they're frequently rewritten); they get no `.md5` and no corruption check. Don't assume every PRST file is hash-protected.
+- **A fingerprint-0 file has no fingerprint word.** The body offset shifts from 12 to 8. Code that pokes a fixed offset (like the LLR2 munging's offset-12 iteration) implicitly assumes a fingerprinted file — it guards on size `> 16` but not on whether a fingerprint is present.
+
+## 7. Quick reference
+
+Header bytes: `[0:4]` magic `0x9f2b3cd4` · `[4]` appid (PRST 4) · `[5]` format_version (0) · `[6]` TYPE · `[7]` version (0) · `[8:12]` fingerprint (if ≠ 0) · then body.
+
+| You want to… | Where / how |
+|---|---|
+| Add a new checkpointable state | new `TaskState` subclass, **append** an unused `TYPE` (≥ 12), implement `read`/`write` calling `TaskState::` first |
+| Extend an existing record | append fields at the end + bump `version()` + branch in `read` (don't reorder) |
+| Make a file skip hashing | set `File::hash = false` before writing |
+| Give a child file a distinct id | `File::unique_fingerprint(parent_fp, "<salt>")` |
+| Persist nothing (but satisfy a `File&`) | `FileEmpty` |
+| Pack many files into one blob | `FilePacked` + `container::FileContainer` (proof `.pack`) |
+| Interop with LLR2 checkpoints | `LLR2File` (local) / `LLR2NetFile` (HTTP) |
+| Encode a signed bignum | `Writer::write(Giant)` — sign rides the length field |
+
+## 8. Open questions / non-coverage
+
+- **`SerializedGWNum` internals.** This doc treats it as "uint32 word count + words" on the wire (`file.cpp:37-41, 146-157`); what those words *mean* (the GWnum `gwserialize` representation) is a GWnum concern, covered at the binding level in `arithmetic-foundation.md` §5. Whether a serialized value is portable across FFT *lengths* for the same modulus (and thus whether a `SerializedGWNum`-only checkpoint survives a reliable-mode FFT bump) is an open question flagged there — do **not** assume the earlier wording that it's "only meaningful to a compatible FFT setup"; that was unverified.
+- **`container::FileContainer` / `Packer`.** The `.pack` streaming format (`container.{h,cpp}`, ~1800 lines of JSON-framed binary with its own MD5/codec/recovery) is summarized in `proof-system.md` §6 as a contract; the implementation is still unowned by any doc.
+- **The MD5 implementation** (`md5.c`) is stock RFC 1321; not reviewed here beyond its interface.
+- **Endianness.** All multi-byte writes are raw host-order (`write((char*)&value, sizeof)`), so checkpoints are implicitly little-endian and not portable to a big-endian host. PRST targets x86/ARM-LE, so this is academic — but it's an unstated assumption, not a guarantee.
+- **The `format_version` byte (offset 5)** is always 0 and never branched on; it's a reserved second escape hatch alongside the per-TYPE `version` byte. Its intended use vs. `version()` isn't documented in code.

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -1,0 +1,470 @@
+# Task lifecycle — deep dive
+
+The layer between `Run`-class orchestration and GWnum's FFT multiplications. A `Task` is "a long-running bignum computation that periodically checkpoints, reports progress, and survives transient FFT-numerical errors." Understanding it is the prerequisite for almost any non-trivial fix in `src/`.
+
+Source files:
+- `task.h`
+- `task.cpp`
+- `prst/src/exp.h` / `exp.cpp` (concrete `BaseExp`-family tasks)
+- `prst/src/lucasmul.h` / `lucasmul.cpp` (Lucas-sequence tasks)
+- `prst/src/proof.h` (`ProofSave` / `ProofBuild` tasks)
+
+Cross-references: `logging-and-progress.md` for how Task drives Progress; `lay-of-the-land.md` for the one-paragraph summary of this layer.
+
+## 1. Class hierarchy at a glance
+
+```
+TaskState                                 (base for any serializable iteration state)
+├── BaseExp::State
+│   ├── BaseExp::StateSerialized          TYPE=8   (mid-task: SerializedGWNum)
+│   └── BaseExp::StateValue               TYPE=1   (final iteration: Giant)
+├── StrongCheckMultipointExp::StrongCheckState   TYPE=2   (Gerbicz/Li check intermediates: _recovery, X, D)
+├── LucasVMulFast::State                  TYPE=9   (single V plus index + parity)
+├── LucasUVMul::State                     TYPE=10  (V_n, V_{n+1}, parity)
+├── LucasUVMul::StrongCheckState          TYPE=11  (UV-form Gerbicz check intermediates)
+├── Proof::Product                        TYPE=3   (proof-product checkpoint)
+├── Proof::Certificate                    TYPE=4   (final certificate written by ProofBuild)
+└── Proof::State                          TYPE=6   (proof checkpoint state)
+
+Task                                       (abstract; restart loop, progress hook, abort)
+└── InputTask                              (adds InputNum*, _timer, error-check toggles)
+    ├── BaseExp                            (abstract; X_n exponentiation primitives)
+    │   ├── CarefulExp                     (single careful exponentiation)
+    │   ├── MultipointExp                  (multi-point exponentiation; proof-friendly)
+    │   │   ├── SmoothExp                  (smooth-exponent variant: factors into small primes)
+    │   │   ├── FastExp                    (binary-method exponentiation, no proof points)
+    │   │   ├── SlidingWindowExp           (sliding-window exponentiation; precomputed table)
+    │   │   └── StrongCheckMultipointExp   (adds Gerbicz / Gerbicz-Li check)
+    │   │       ├── GerbiczCheckExp        (classic Gerbicz error check)
+    │   │       ├── LiCheckExp             (Gerbicz-Li check, paper eprint 2023/195)
+    │   │       └── FastLiCheckExp         (LiCheck on top of fast/sliding-window math)
+    │   └── Product                        (accumulates a product of giants)
+    ├── LucasVMul                          (abstract Lucas V multiplier)
+    │   ├── LucasVMulFast                  (precomputed Lucas chains over a factor list)
+    │   ├── LucasUVMul                     (UV form; supports strong-check)
+    │   └── LucasUVMulFast                 (UV-form variant for fast paths)
+    ├── ProofSave                          (-proof save: writes proof points during a Fermat run)
+    └── ProofBuild                         (-proof build: consumes points, emits certificate)
+```
+
+The `TYPE` constants are on-disk discriminators in `TaskState` subclasses — they're the file format version, do not reuse or renumber.
+
+## 2. `TaskState` — the serializable iteration anchor
+
+```cpp
+class TaskState {
+    char _type;           // TYPE constant, sets the on-disk version
+    bool _written;        // whether this state has been flushed to _file already
+    int  _iteration;      // current iteration count (the only field the base class persists)
+
+    void set(int iteration);      // resets _written to false and stores _iteration
+    virtual bool read(Reader&);   // base reads _iteration only
+    virtual void write(Writer&);  // base writes _iteration only
+    void set_written();           // mark state as flushed; Task::write_state skips re-writing
+    char type();                  // returns _type (the on-disk discriminator)
+    char version() { return 0; }  // unused on-disk version field; reserved for future schema bumps
+    bool is_written();             // returns _written
+    int  iteration();              // returns _iteration
+};
+
+template<class State>
+State* read_state(File* file);   // null-safe deserializer
+```
+
+Subclasses override `read()` / `write()` and add their own fields (`_giant_value`, `_serialized_value`, `_V` / `_Vn` / `_Vn1`, etc.). `read_state<T>(file)` is the canonical way to load a checkpoint: returns a fresh `T` if the file decodes, or `nullptr`. The `_written` flag prevents re-writing a state that's already on disk in `Task::write_state()` (`task.cpp:192`).
+
+Subclasses' `set(...)` methods take the same `int iteration` first arg plus any state-specific payload. `BaseExp::StateValue::set(iteration, GWNum&)` for example writes a `Giant`; `BaseExp::StateSerialized::set(iteration, GWNum&)` writes a `SerializedGWNum` (cheaper to checkpoint mid-task).
+
+## 3. `Task` fields — annotated
+
+```cpp
+class Task {
+    bool _error_check = false;                                  // promoted to ReliableGWArithmetic when true
+    arithmetic::GWState* _gwstate = nullptr;                    // owning GWnum runtime; configured by main()
+    arithmetic::GWArithmetic* _gw = nullptr;                    // active arithmetic; flips between two slots in run()
+    std::unique_ptr<TaskState> _state;                          // current durable state
+    std::unique_ptr<TaskState> _tmp_state;                      // scratch slot, swapped into _state to amortize allocation
+    int _iterations = 0;                                        // total iteration count for this task instance
+    int _state_update_period = MULS_PER_STATE_UPDATE;           // how often commit_execute checkpoints
+    File* _file;                                                // checkpoint File (may be null for transient tasks)
+    Logging* _logging;                                          // Logging or SubLogging instance for progress + reports
+    std::chrono::system_clock::time_point _last_write;          // for DISK_WRITE_TIME pacing
+    std::chrono::system_clock::time_point _last_progress;       // for PROGRESS_TIME pacing
+    static bool _abort_flag;                                    // process-wide cooperative cancel
+    int _restart_count = 0;                                     // restarts within current execute() pass
+    int _restart_op = 0;                                        // op index from which to resume after a reliable restart
+    double _op_count = 0;                                       // accumulated op count across restarts
+    double _op_base = 0;                                        // _gwstate->ops() snapshot at start of current pass
+};
+```
+
+Public surface:
+
+```cpp
+static void abort();              // signal handler calls this from prst/src/prst.cpp:38
+static void abort_reset();        // clear the static _abort_flag (used by tests / batch mode)
+static bool abort_flag();         // read the static _abort_flag
+virtual void run();               // the main entry point
+arithmetic::GWArithmetic& gw();   // active arithmetic (after init); used by setup()/execute() to issue ops
+TaskState* state();               // current durable state; null before first commit
+int iterations();                 // total iteration count for this task instance (set by init)
+int state_update_period();        // _state_update_period; commit_execute uses it to gate checkpoints
+bool is_last(int iteration);      // true when next commit will checkpoint
+virtual double progress();        // 0..1; default = state()->iteration() / iterations()
+int ops();                        // accumulated reliable op count
+```
+
+### `InputTask` adds
+
+```cpp
+class InputTask : public Task {
+    InputNum* _input = nullptr;         // candidate being tested; needed for FFT re-setup on restart
+    double _timer = 0;                  // wall-clock anchor; getHighResTimer() at init, elapsed at done()
+    bool _error_check_near = true;      // auto-enable error check when near FFT limit
+    bool _error_check_forced = false;   // unconditionally enable error check
+
+    void set_error_check(bool near, bool check);   // toggle the two flags above; recomputes _error_check
+    double timer();                     // !! see Pitfall G — only meaningful AFTER done()
+};
+```
+
+Most concrete tasks derive from `InputTask`. The `_timer` field is the wall-clock measurement of how long this single task ran.
+
+## 4. The cadence knobs
+
+Three static knobs on `Task` control pacing (`task.cpp:27-29`):
+
+| Constant                   | Default | What it gates                                                                                       |
+|----------------------------|---------|-----------------------------------------------------------------------------------------------------|
+| `MULS_PER_STATE_UPDATE`    | 20000   | Default `_state_update_period`. Subclasses may shrink it (e.g. `MultipointExp` for high-base smooth exponents at `prst/src/exp.cpp:135`). |
+| `DISK_WRITE_TIME`          | 300 s   | Wall-clock interval between disk checkpoints in `on_state()`.                                       |
+| `PROGRESS_TIME`            | 10 s    | Wall-clock interval between `report_progress()` calls in `on_state()`.                              |
+
+`MULS_PER_STATE_UPDATE` is iteration-based; the others are time-based. They run independently. Both `DISK_WRITE_TIME` and `PROGRESS_TIME` use `std::chrono::system_clock` (not `getHighResTimer`).
+
+## 5. Annotated `Task::run()`
+
+The retry-loop is the hardest part to read at a glance. From `task.cpp:45-151`, with annotations:
+
+```cpp
+void Task::run() {
+    ReliableGWArithmetic* reliable;
+    std::unique_ptr<arithmetic::GWArithmetic> arithmetics[2];   // [0]=setup pass, [1]=execute pass
+
+    int setup_restart_count = 0;
+    _restart_count = 0;
+    _restart_op = 0;
+    int* restart_count[2] { &setup_restart_count, &_restart_count };
+
+    while (true) {                                              // OUTER: per-FFT-size attempt
+        _op_base = _gwstate->ops();
+        int i;
+        for (i = 0; i < 2; ) {                                  // INNER: 0=setup, 1=execute
+            if (!arithmetics[i])
+                arithmetics[i].reset(_error_check ? new ReliableGWArithmetic(*_gwstate)
+                                                  : new GWArithmetic(*_gwstate));
+            _gw = arithmetics[i].get();
+            reliable = dynamic_cast<ReliableGWArithmetic*>(_gw);
+
+            try {
+                if (i == 0) setup();
+                if (i == 1) execute();
+                *restart_count[i] = 0;                          // pass succeeded; clear its counter
+                i++;
+                continue;
+            }
+            catch (const TaskRestartException&) {
+                if (!reliable) {                                // first restart: promote to reliable
+                    release(); _gw = nullptr;
+                    _op_count = _gwstate->ops() - _op_base;
+                    _op_base = _gwstate->ops();
+                    _error_check = true;                        // upgrade flag, drop arithmetics
+                    arithmetics[0].reset(); arithmetics[1].reset();
+                }
+                // else: fall through to restart logic below
+            }
+            catch (const ArithmeticException& e) {
+                _logging->warning("ArithmeticException: %s\n", e.what());
+            }
+            catch (...) {
+                release(); throw;                                // unrecoverable, bubble up
+            }
+
+            _logging->warning("Arithmetic error, restarting at %.1f%%.\n", 100.0*progress());
+
+            if (reliable && reliable->restart_flag() && !reliable->failure_flag()) {
+                // reliable detected a suspicious op; restart from _restart_op
+                std::string opstr = "pass " + std::to_string(i) + " suspicious ops:";
+                for (auto it = reliable->suspect_ops().begin(); it != reliable->suspect_ops().end(); it++)
+                    if (*it >= (i == 1 ? _restart_op : 0))
+                        opstr += " " + std::to_string(*it);
+                opstr += ".\n";
+                _logging->debug(opstr.data());
+                reliable->restart(i == 1 ? _restart_op : 0);
+                i = 0;                                          // re-run setup before re-execute
+                continue;
+            }
+            if ((!reliable || !reliable->failure_flag()) && *restart_count[i] < 2) {
+                if (reliable) reliable->restart(i == 1 ? _restart_op : 0);
+                (*restart_count[i])++;
+                i = 0;
+                continue;
+            }
+            break;                                              // restart logic exhausted; bump FFT
+        }
+        if (_gw != nullptr) _op_count = _gwstate->ops() - _op_base;
+        if (i == 2) break;                                      // both passes succeeded; we're done
+
+        // ESCAPE: bump FFT and retry from scratch
+        if (_gw != nullptr) release();
+        _gw = nullptr;
+        if (_gwstate->next_fft_count >= 5) {
+            _logging->error("Maximum FFT increment reached.\n");
+            throw TaskAbortException();                          // give up
+        }
+        if (*restart_count[i] >= 5) {
+            _logging->error("Too many restarts, aborting.\n");
+            throw TaskAbortException();
+        }
+        (*restart_count[i])++;
+        _gwstate->next_fft_count++;
+        _logging->report_param("next_fft", _gwstate->next_fft_count);
+        reinit_gwstate();                                        // virtual; InputTask reconfigures FFT
+        _restart_op = 0;
+        arithmetics[0].reset(); arithmetics[1].reset();
+    }
+    _tmp_state.reset();
+    if (_gw != nullptr) release();
+    _gw = nullptr;
+}
+```
+
+Mental model:
+
+- **Two passes.** `setup()` runs once before `execute()`. They use separate `GWArithmetic` instances (slot 0 vs slot 1). Some subclasses do non-trivial work in `setup()` (e.g. `MultipointExp::setup` builds sliding-window tables); others leave it nearly empty.
+- **Three escape routes.** (a) Both passes succeed → break the outer loop. (b) Reliable detected a suspect op → re-restart from `_restart_op` without bumping FFT. (c) Restart budget exceeded → bump `next_fft_count`, call `reinit_gwstate()`, retry. After 5 FFT increments or 5 same-pass restarts → `TaskAbortException`.
+- **Promotion to reliable.** First `TaskRestartException` upgrades the task: `_error_check = true`, drop both arithmetic slots, the next iteration constructs `ReliableGWArithmetic`. After that the suspect-op restart path is available.
+
+## 6. Annotated `Task::on_state()`
+
+The periodic callback every concrete task hits via `commit_execute<TState>`. From `task.cpp:163-190`:
+
+```cpp
+void Task::on_state() {
+    bool state_save_flag = _logging->state_save_flag();
+
+    // 1. Disk-save tick: every DISK_WRITE_TIME seconds, on abort, or on logging request.
+    if (now - _last_write >= DISK_WRITE_TIME || abort_flag() || state_save_flag) {
+        _logging->debug("saving state to disk.\n");          // visible only at LEVEL_DEBUG
+        _logging->progress().update(progress(), ops());     // anchors timer / accrues elapsed
+        _logging->state_save();                              // virtual; default no-op, BOINC overrides
+        write_state();                                       // _file->write(*_state) if file present
+        _last_write = now;                                   // reset DISK_WRITE_TIME pacer
+        _logging->progress().update(progress(), ops());     // re-anchor after I/O wall-clock
+        _logging->progress_save();                           // .param file write
+    }
+
+    // 2. Honor cooperative abort BEFORE potentially running progress logic.
+    if (abort_flag()) throw TaskAbortException();            // SIGTERM/SIGINT path; caught in run() callers
+
+    // 3. Progress tick: every PROGRESS_TIME seconds.
+    if (now - _last_progress >= PROGRESS_TIME) {
+        _logging->progress().update(progress(), ops());     // accrue elapsed before formatting
+        _logging->report_progress();                         // emits "X.X% done…" line
+        _last_progress = now;                                // reset PROGRESS_TIME pacer
+    }
+
+    // 4. If we're running reliable, snapshot the latest known-good op for restart.
+    if (_error_check && _gw != nullptr) {
+        ReliableGWArithmetic* reliable = dynamic_cast<ReliableGWArithmetic*>(_gw);
+        _restart_op = reliable->op();
+    }
+
+    // 5. Always: heartbeat (BOINC).
+    _logging->heartbeat();
+}
+```
+
+Cross-ref: this is the place inside the framework that drives the **recurring/periodic** `Progress::update()` ticks from a Task's perspective. It is not the only call site, though: `Task::init` calls `progress().update(0, ops())` to anchor the timer at task start (`task.cpp:40`), and `InputTask::done` calls `progress().update(1, ops())` to mark the stage 100% complete at task end (`task.cpp:235`). Every long task automatically generates the periodic ticks that populate `_time_total` on its `Logging`'s `Progress` (see `logging-and-progress.md` §7).
+
+## 7. State machinery
+
+The pattern is:
+
+```cpp
+// In subclass execute() loop:
+for (i = state ? state->iteration() : 0; i < iterations(); i++) {
+    /* one iteration of math: e.g. X = X*X */
+    commit_execute<MyState>(i + 1, /* ctor args for MyState::set */);
+}
+```
+
+What `commit_execute<T>` does (`task.h:96`):
+
+1. Checks the cadence condition: `iteration - last_state_iter >= state_update_period || iteration == iterations() || abort_flag() || state_save_flag()`.
+2. If true: call `check()` (which throws `TaskRestartException` if reliable detected a problem), then `set_state<T>(iteration, args...)`.
+3. If false: skip — let the math loop continue without snapshotting.
+
+What `set_state<T>` does (`task.h:105`):
+
+1. If `_tmp_state` is null or wrong type, allocate a fresh `T` into `_tmp_state`.
+2. Call `_tmp_state->set(iteration, args...)`.
+3. **Swap** `_tmp_state` and `_state`. Now the new state is durable, the old one is the scratch slot for next iteration. This is why two slots exist — to amortize allocation across iterations.
+4. Call `on_state()` — which might checkpoint to disk, report progress, throw on abort, or do nothing.
+
+`reset_state<T>()` (`task.h:113-118`) would drop any existing state, install a fresh `T()`, and call `on_state()` — but it has **no live callers** anywhere in the tree, so treat it as effectively dead code rather than a recommended pattern. When a subclass wants to start clean (e.g., `MultipointExp::execute` at `prst/src/exp.cpp:202-206` when there's no checkpoint and no `_smooth`), the real pattern is to construct the state directly and hand it to `init_state` — `tmp_state = new StateSerialized()` followed by `init_state(tmp_state)` — not `reset_state`.
+
+`is_last(iteration)` (`task.h:82`) is the same predicate as `commit_execute`'s gate. Subclasses use it to decide whether the next iteration is a snapshotting boundary — useful when the math has work that should only happen at boundaries (e.g. switching from `SerializedGWNum` to a final `Giant`).
+
+`commit_setup()` (`task.cpp:203`) is a different call, made from inside `setup()`: it runs `check()` and resets reliable state if needed. Subclasses that perform work in `setup()` should call it at the end of that work.
+
+## 8. The error-correction subsystem
+
+Two exception types drive recovery:
+- `TaskRestartException` — "this pass needs to redo from a known-good op." Caught in `run()`'s inner loop.
+- `TaskAbortException` — "abandon this task entirely." Caught by callers (e.g., `prst/src/prst.cpp:423`).
+
+`ReliableGWArithmetic` is GWnum's verifier-wrapping arithmetic. It exposes:
+- `restart_flag()` — "I detected something suspicious; please restart."
+- `failure_flag()` — "the suspicious op was confirmed bad; restart from a backup."
+- `suspect_ops()` — the op indices that look wrong.
+- `restart(op)` — rewind internal state to operation `op`.
+
+`Task::check()` (`task.cpp:153`) is called from inside `commit_execute` and `commit_setup`. If reliable's `restart_flag` or `failure_flag` is set, it throws `TaskRestartException`. The exception is then caught in `run()`, which decides whether to (a) re-run from `_restart_op` (still inside the same FFT size) or (b) bump FFT.
+
+`_restart_op` is updated inside `on_state()` (`task.cpp:184-188`): when running reliable, the most recent reliable op count is snapshotted there. After a restart, that's where execution resumes.
+
+`InputTask::reinit_gwstate()` (`task.cpp:221`) is what `Task::run` calls when bumping FFT size: tears down `_gwstate`, calls `_input->setup(*_gwstate)` again, warns the user (preserving any prefix), recomputes `_error_check_near` against the new FFT.
+
+## 9. `InputTask::init` and `done`
+
+```cpp
+void InputTask::init(InputNum* input, GWState* gwstate, File* file, TaskState* state, Logging* logging, int iterations) {
+    Task::init(gwstate, file, state, logging, iterations);
+    _input = input;                                              // remember for FFT re-setup on restart
+    _timer = getHighResTimer();                                  // start wall-clock anchor
+    _error_check = _error_check_near                             // either: auto-on near FFT limit
+        ? gwnear_fft_limit(gwstate->gwdata(), 1) == TRUE         // or: respect the forced flag
+        : _error_check_forced;
+}
+
+void InputTask::done() {
+    _timer = (getHighResTimer() - _timer) / getHighResTimerFrequency();   // convert to elapsed seconds
+    _logging->progress().update(1, ops());                       // mark stage 100% complete; flushes elapsed up the parent chain
+    _logging->debug("task time: %.3f s, ops: %d, time per op: %.3f ms.\n",  // debug-only summary
+                    _timer, ops(), _timer*1000/ops());
+}
+```
+
+Key consequence: `task->timer()` is **the start anchor** during `run()`, and **the elapsed seconds** only after `done()` returns. Pitfall G below.
+
+`_error_check` is decided at init based on whether the FFT is close to its safety limit (`_error_check_near` mode) OR forced on (`_error_check_forced`). Subclasses can change this with `set_error_check(near, check)` before running.
+
+## 10. Concrete subclasses — one-paragraph tour
+
+- **`BaseExp`** (`prst/src/exp.h:11`). Abstract base for X^k mod N exponentiation. Owns `_exp` (the exponent), `_tail`, `_X0` / `_x0` (starting value), `_smooth` flag. Provides three nested state classes: `State` (abstract), `StateSerialized` (cheap mid-task representation), `StateValue` (final-iteration `Giant`). The override of `commit_execute` at `prst/src/exp.h:67-74` switches automatically between the two state types based on whether `iteration == iterations()`.
+
+- **`CarefulExp`** (`prst/src/exp.h:93`). Single careful exponentiation; no error-check restart path. Used for short side-tasks (Pocklington's per-factor checks, Order's tail).
+
+- **`MultipointExp`** (`prst/src/exp.h:138`). Exponentiation that hits a list of `_points` (intermediate iteration counts) where checkpoints are forced. Used by the proof system (each point is a proof point), and by Fermat tests with checkpoints. Shrinks `_state_update_period` for high-base smooth exponents (`prst/src/exp.cpp:135`).
+
+- **`StrongCheckMultipointExp` / `GerbiczCheckExp` / `LiCheckExp` / `FastLiCheckExp`** (`prst/src/exp.h:302+`). Layer Gerbicz / Gerbicz-Li strong error checks on top of MultipointExp. They use `StrongCheckState` to persist the check-side intermediate. The math is documented in this framework's `docs/mult_*.pdf`.
+
+- **`Product`** (`prst/src/exp.h:545`). Accumulates a product of giants. Used in `MorrisonGeneric` / `PocklingtonGeneric` to compute the product of cofactor pieces (`prst/src/morrison.cpp:531`, `prst/src/pocklington.cpp:377`).
+
+- **`LucasVMul` / `LucasVMulFast`** (`prst/src/lucasmul.h:9, 29`). Lucas V-sequence multiplier. State holds a single `Giant V` plus a parity flag and an index. `LucasVMulFast` exposes `mul_giant` / `mul_prime` to register the factor list before running.
+
+- **`LucasUVMul` / `LucasUVMulFast`** (`prst/src/lucasmul.h:104, 206`). UV-form Lucas multiplier, with an optional strong-check via `StrongCheckState`. Used by `Morrison`'s main test path.
+
+- **`ProofSave` / `ProofBuild`** (`prst/src/proof.h:140, 159`). Proof-system tasks: `ProofSave` writes proof points during a Fermat run; `ProofBuild` consumes them on the verifier side. Both layer their own state types over `InputTask`.
+
+## 11. Common patterns
+
+### Pattern: a Run-class running a single task
+
+```cpp
+// In Foo::run()
+File* checkpoint = file_checkpoint.add_child(...);
+_task->init(&input, &gwstate, checkpoint, &logging, ...);
+_task->run();
+Giant* result = _task->result();
+if (result == nullptr) { /* aborted or failed */ }
+// ... use result ...
+_task.reset();
+checkpoint->clear();
+```
+
+After `run()` returns normally, `result()` is non-null and `task->timer()` is the elapsed seconds.
+
+### Pattern: resume from checkpoint
+
+`init()` is responsible for picking up state. The convention:
+
+```cpp
+void Foo::init(...) {
+    InputTask::init(input, gwstate, file, /*state*/ nullptr, logging, iterations);
+    State* state = read_state<State>(file);                  // null-safe load
+    if (state != nullptr) init_state(state);                 // restore _state, sync progress
+}
+```
+
+If the file is fresh, `read_state` returns null and the task starts at iteration 0. If it has saved data, the task picks up at `state->iteration()`.
+
+### Pattern: sub-task under a `SubLogging`
+
+See `logging-and-progress.md` §9 for the full pattern. Briefly: register an outer stage, hand the inner task a `SubLogging`, run it, then call the **outer** `progress().update(progress_stage(), 0)` to credit elapsed time durably to outer's `_time_total`.
+
+### Pattern: chained tasks (Fermat → factor checks)
+
+`Fermat::run` runs the main exponentiation, then `Pocklington::run` (or its loop) creates per-factor `CarefulExp` tasks one at a time, each fed by the running result of the previous. Each sub-task has its own `init` / `run` / `result` lifecycle; checkpoints are scoped via `file.add_child(...)`.
+
+## 12. Pitfalls
+
+### A. Subclass `setup()` without `commit_setup()` at the end
+`commit_setup()` runs `check()` and resets reliable state. If your `setup()` does GW operations and skips `commit_setup`, a suspicious-op detection during setup never escalates into a `TaskRestartException`, and `_restart_op` semantics get confused. Rule: any `setup()` that touches `_gw` must end with `commit_setup()`. See `MultipointExp::setup` at `prst/src/exp.cpp:171-172` for the canonical pattern.
+
+### B. Mutating `_state` directly
+`_state` is a `unique_ptr<TaskState>`. Don't reassign it from a subclass — go through `set_state<T>` / `commit_execute<T>` (or `reset_state<T>`, which routes through `on_state()` correctly but has no live callers — see §7). Direct assignment bypasses `on_state()`, so no progress tick, no checkpoint, no abort handling, and the `_tmp_state` swap protocol breaks.
+
+### C. Reading `task->result()` before completion
+`BaseExp::result()` returns `nullptr` if `state()->iteration() != iterations()` or if the state isn't a `StateValue` (`prst/src/exp.h:66`). `LucasVMulFast::result()` and `LucasVMul::result()` similarly guard. Don't dereference before `run()` returns.
+
+### D. Assuming `_state_update_period == MULS_PER_STATE_UPDATE`
+`MultipointExp::init` (`prst/src/exp.cpp:133-135`) shrinks `_state_update_period` for smooth exponents with base > 2. If you write code that's tuned to the static default (e.g. estimating disk bandwidth from a known checkpoint cadence), it'll be wrong for those cases. Read `task->state_update_period()` if you need the actual value.
+
+### E. Calling `Task::abort()` from a non-signal-handler thread
+Currently fine — it just sets `bool _abort_flag`. But it isn't documented as MT-safe; if anyone ever runs Tasks in parallel above GWnum, this needs `std::atomic<bool>` and acquire/release semantics. Treat `abort()` as a process-wide one-shot.
+
+### F. Subclass swallowing `TaskRestartException` / `TaskAbortException`
+Both are caught by `Task::run()` and are part of its protocol. If a subclass `setup()`/`execute()` catches them locally and converts them into something else, the restart machinery never engages. Rule: don't catch `TaskRestartException` or `TaskAbortException` inside `setup` / `execute`; let them propagate.
+
+### G. Reading `InputTask::timer()` mid-run
+During `run()`, `_timer` holds the start `getHighResTimer()` reading. Only after `done()` does it become elapsed seconds. If you log or push `task->timer()` from inside the run loop, you'll get garbage (a ~13-digit timer count). Read it only after the task completes — typically right after the next `task->run()` call returns or in a result-gathering pass.
+
+### H. Forgetting `add_child` for sub-task files
+A sub-task that shares the parent's checkpoint file will overwrite the parent's state. Always allocate a child file via `file.add_child(name, fingerprint)` for any sub-task. See `prst/src/morrison.cpp:224` for the canonical uniqueness pattern (`checkpoint = file_checkpoint.add_child(sP, File::unique_fingerprint(file_checkpoint.fingerprint(), sP));`), with the recovery-point analogue at `:229`; `File::unique_fingerprint` is also used at `:363` and `:516`.
+
+## 13. Quick reference
+
+| You want to…                                                        | Call                                                                                  |
+|---------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| Define a new persistent state                                       | Subclass `TaskState`, pick a unique `TYPE`, override `read`/`write`                   |
+| Define a new task                                                   | Subclass `InputTask`, override `setup` + `execute` + `release` (+ `reinit_gwstate` if non-trivial) |
+| Advance state inside an iteration loop                              | `commit_execute<MyState>(iter, args...)` after each math step                         |
+| Force a checkpoint to disk                                          | `commit_execute<MyState>(iterations(), args...)` (the `iter == iterations()` path)    |
+| Start state clean (no checkpoint)                                   | `new MyState()` + `init_state(state)` (see `prst/src/exp.cpp:202-206`); `reset_state<MyState>()` exists at `task.h:113-118` but has no live callers |
+| Read state from a checkpoint file                                   | `read_state<MyState>(_file)` in `init`, then `init_state(state)`                      |
+| Signal a restart from a known-good op (reliable mode)               | Throw `TaskRestartException` (or rely on `check()` to throw via reliable's flags)     |
+| Cooperatively cancel from outside                                   | `Task::abort()` (sets the static bool; tasks honor it at next `on_state`)             |
+| Capture a task's wall-clock duration                                | Read `((InputTask*)task)->timer()` **after** `task->run()` returns                    |
+| Allocate a unique sub-task checkpoint file                          | `parent_file.add_child(name, File::unique_fingerprint(parent_fp, name))`              |
+| Force error-check on for the whole run                              | `task->set_error_check(/*near*/false, /*check*/true)` before `task->init`             |
+| Bump checkpoint frequency for a single task                         | Set `_state_update_period` after calling base `init`                                  |
+
+## 14. Open questions / non-coverage
+
+- **The math.** Gerbicz-Li's algorithm, Lucas chain construction, sliding-window exponentiation, Proth/Pocklington/Morrison theorem details. See `docs/mult_en_20230925.pdf` for the multiplication theory; the test theorems themselves are in the upstream README and the original papers.
+- **GWnum internals.** FFT selection, thread-pool layout, instruction-set dispatch. Owned by the gwnum prebuilt (third-party).
+- **`ReliableGWArithmetic` internals.** How GWnum decides an op is suspect, what `failure_flag` means concretely. Treat it as a black box for now — its public flags are the contract.
+- **State serialization format.** `Giant`/`SerializedGWNum`/etc. all have custom `read`/`write` that go through `Reader`/`Writer` in `file.cpp`. Worth its own short doc if we ever need to bump a `TaskState::TYPE` constant or extend the on-disk schema.
+- **The `_smooth` exponentiation path.** `BaseExp::_smooth` toggles a different math path (used when the exponent factors smoothly into small primes). Worth a footnote in any future "exponentiation algorithms" doc.


### PR DESCRIPTION
Adds a `docs/` folder with developer documentation for this library: a top-level orientation (`lay-of-the-land.md`) plus 8 per-subsystem deep-dives — Task lifecycle, logging/progress, InputNum parsing, state serialization, the arithmetic foundation (Giant/GWArithmetic + number theory), curves & polynomials, the config DSL, and the container format.

Docs-only. These guides were originally drafted in `patnashev/prst` (PR #17) but document this repo's code, so they belong here alongside it — that PR is being trimmed to the PRST application docs. Path citations are rebased to this repo's layout (framework submodule contents = repo root); cross-repo references into the consuming PRST application are qualified as `prst/src/...`, and the companion application deep-dives are noted as living in `patnashev/prst/docs/`.

Written against current `main` (379f04e). Embedded `file:line` citations reflect the tree at writing time — re-grep before trusting any specific line number. Happy to relocate, rename, or trim anything.